### PR TITLE
Add Fabric with Modrinth: merged loader, in-terminal mod browser, starter bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test lint clean dev
+.PHONY: build run test lint clean dev reset-auth damage-auth reset-all
 
 # Build the binary
 build:
@@ -53,11 +53,25 @@ build-all:
 	GOOS=linux GOARCH=amd64 go build -o dist/mctui-linux-amd64 .
 	GOOS=windows GOARCH=amd64 go build -o dist/mctui-windows-amd64.exe .
 
+# Default app data dir (override for portable layout: make damage-auth MCTUI_DATA_DIR=./data)
+# Matches config.getDefaultDataDir when XDG_DATA_HOME is unset and not using APPDATA.
+MCTUI_DATA_DIR ?= $(HOME)/.local/share/mctui
+ACCOUNTS_JSON := $(MCTUI_DATA_DIR)/accounts.json
+
 # Reset authentication (deletes accounts.json)
-# Note: config path logic might vary, this assumes default Linux/Mac path
 reset-auth:
-	rm -f ~/.local/share/mctui/accounts.json
+	rm -f $(ACCOUNTS_JSON)
+
+# Corrupt stored MSA tokens for testing session validation / re-login (keeps accounts.json)
+damage-auth:
+	@test -f $(ACCOUNTS_JSON) || (echo "No accounts file at $(ACCOUNTS_JSON); sign in once, or set MCTUI_DATA_DIR." && false)
+	@command -v jq >/dev/null || (echo "damage-auth needs jq (e.g. brew install jq)" && false)
+	@jq -e '[.accounts[]? | select(.type == "msa")] | length > 0' "$(ACCOUNTS_JSON)" >/dev/null \
+		|| (echo "No MSA accounts in $(ACCOUNTS_JSON)" && false)
+	jq '.accounts |= map(if .type == "msa" then . + {accessToken: "__mctui_damage_auth__", expiresAt: "2099-01-01T00:00:00Z"} else . end)' \
+		"$(ACCOUNTS_JSON)" > "$(ACCOUNTS_JSON).tmp" && mv "$(ACCOUNTS_JSON).tmp" "$(ACCOUNTS_JSON)"
+	@echo Damaged MSA tokens in $(ACCOUNTS_JSON)
 
 # Reset all data (instances, cache, auth)
 reset-all:
-	rm -rf ~/.local/share/mctui
+	rm -rf $(MCTUI_DATA_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test lint clean dev reset-auth damage-auth reset-all
+.PHONY: build run dev test test-cover lint fmt tidy clean build-all reset-auth damage-auth reset-all
 
 # Build the binary
 build:
@@ -41,13 +41,14 @@ fmt:
 tidy:
 	go mod tidy
 
-# Clean build artifacts
+# Clean build artifacts (binary, coverage, cross-build output in dist/)
 clean:
-	rm -f mctui
-	rm -f coverage.out coverage.html
+	rm -f mctui coverage.out coverage.html
+	rm -rf dist
 
-# Build for all platforms
+# Build for all platforms (writes to dist/)
 build-all:
+	mkdir -p dist
 	GOOS=darwin GOARCH=amd64 go build -o dist/mctui-darwin-amd64 .
 	GOOS=darwin GOARCH=arm64 go build -o dist/mctui-darwin-arm64 .
 	GOOS=linux GOARCH=amd64 go build -o dist/mctui-linux-amd64 .

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,12 @@ module github.com/quasar/mctui
 go 1.25.4
 
 require (
+	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.10.1
 	github.com/dustin/go-humanize v1.0.1
-	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
 )
 
@@ -16,7 +17,6 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/harmonica v0.2.0 // indirect
-	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/quasar/mctui
+module github.com/mctui/mctui
 
 go 1.25.4
 

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
+github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
@@ -28,8 +30,6 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -5,12 +5,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"time"
 )
+
+// ErrMinecraftSessionInvalid means the Minecraft access token was rejected
+// (expired, revoked, or otherwise invalid).
+var ErrMinecraftSessionInvalid = errors.New("minecraft session invalid or expired")
 
 var (
 	msaDeviceCodeURL = "https://login.microsoftonline.com/consumers/oauth2/v2.0/devicecode"
@@ -144,7 +149,7 @@ func (c *AuthClient) PollForToken(ctx context.Context, dc *DeviceCodeResponse) (
 		if err != nil {
 			continue // Network error, retry
 		}
-		
+
 		var result struct {
 			MSATokenResponse
 			Error string `json:"error"`
@@ -259,7 +264,13 @@ func (c *AuthClient) FetchProfile(ctx context.Context, accessToken string) (*Min
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	switch resp.StatusCode {
+	case http.StatusUnauthorized:
+		return nil, fmt.Errorf("%w", ErrMinecraftSessionInvalid)
+	case http.StatusOK:
+		// ok
+	default:
+		// 403 etc. may mean “no game license” or other policy — not always “re-run OAuth”.
 		return nil, fmt.Errorf("fetch profile failed: %d", resp.StatusCode)
 	}
 
@@ -268,4 +279,12 @@ func (c *AuthClient) FetchProfile(ctx context.Context, accessToken string) (*Min
 		return nil, err
 	}
 	return &result, nil
+}
+
+// ValidateMinecraftToken checks that accessToken is accepted by Minecraft Services
+// (same contract as the game launch). Use errors.Is(err, ErrMinecraftSessionInvalid)
+// to detect a token that needs re-login.
+func (c *AuthClient) ValidateMinecraftToken(ctx context.Context, accessToken string) error {
+	_, err := c.FetchProfile(ctx, accessToken)
+	return err
 }

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -93,5 +94,42 @@ func TestAuthClient_PollForToken(t *testing.T) {
 	}
 	if attempts != 2 {
 		t.Errorf("Expected 2 attempts, got %d", attempts)
+	}
+}
+
+func TestAuthClient_FetchProfile_unauthorized(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer bad" {
+			t.Errorf("Authorization header: %q", r.Header.Get("Authorization"))
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer ts.Close()
+
+	old := mcProfileURL
+	mcProfileURL = ts.URL
+	defer func() { mcProfileURL = old }()
+
+	client := NewAuthClient("dummy")
+	_, err := client.FetchProfile(context.Background(), "bad")
+	if !errors.Is(err, ErrMinecraftSessionInvalid) {
+		t.Fatalf("err = %v, want ErrMinecraftSessionInvalid", err)
+	}
+}
+
+func TestAuthClient_ValidateMinecraftToken_ok(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(MinecraftProfile{ID: "u", Name: "n"})
+	}))
+	defer ts.Close()
+
+	old := mcProfileURL
+	mcProfileURL = ts.URL
+	defer func() { mcProfileURL = old }()
+
+	client := NewAuthClient("dummy")
+	if err := client.ValidateMinecraftToken(context.Background(), "token"); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/api/modrinth.go
+++ b/internal/api/modrinth.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	modrinthBaseURL = "https://api.modrinth.com/v2"
-	userAgent       = "quasar/mctui/1.0.0 (github.com/quasar/mctui)"
+	userAgent       = "mctui/1.0.0 (github.com/mctui/mctui)"
 )
 
 // ModrinthClient handles Modrinth API interactions

--- a/internal/api/mojang.go
+++ b/internal/api/mojang.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/quasar/mctui/internal/core"
+	"github.com/mctui/mctui/internal/core"
 )
 
 const (

--- a/internal/api/mojang.go
+++ b/internal/api/mojang.go
@@ -200,3 +200,8 @@ func (c *MojangClient) saveVersionDetails(versionID string, details *core.Versio
 func (c *MojangClient) versionDetailsPath(versionID string) string {
 	return filepath.Join(c.versionCacheRoot, fmt.Sprintf("%s.json", versionID))
 }
+
+// VersionCacheDir returns the directory used for cached version JSON files.
+func (c *MojangClient) VersionCacheDir() string {
+	return c.versionCacheRoot
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -14,6 +14,7 @@ import (
 	"github.com/quasar/mctui/internal/config"
 	"github.com/quasar/mctui/internal/core"
 	"github.com/quasar/mctui/internal/launch"
+	"github.com/quasar/mctui/internal/loader"
 	"github.com/quasar/mctui/internal/ui"
 )
 
@@ -412,10 +413,13 @@ func (m *Model) startLaunch(inst *core.Instance, offline bool) tea.Cmd {
 		ctx, cancel := context.WithCancel(context.Background())
 		m.launchCtxCancel = cancel
 
-		// Find version info
-		details, err := m.mojang.ResolveVersionDetails(ctx, inst.Version, offline)
+		// Find version info (vanilla or merged loader profile)
+		details, err := loader.ResolveVersionDetails(ctx, m.mojang, inst, offline)
 		if err != nil {
 			return ui.LaunchComplete{Error: err}
+		}
+		if loader.ParseKind(inst.Loader) == loader.KindFabric {
+			_ = m.instances.Update(inst)
 		}
 
 		// Validate version info

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4,7 +4,9 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
@@ -113,6 +115,88 @@ func (m *Model) Init() tea.Cmd {
 	return tea.Batch(
 		m.home.Init(),
 		m.loadInstances(),
+		tea.Sequence(
+			func() tea.Msg { return ui.ActiveSessionCheckStarted{} },
+			m.checkActiveSessionCmd(),
+		),
+	)
+}
+
+func (m *Model) effectiveMSAClientID() string {
+	if m.cfg.MSAClientID != "" {
+		return m.cfg.MSAClientID
+	}
+	return config.DefaultMSAClientID
+}
+
+func (m *Model) prepareAuthScreen() tea.Cmd {
+	m.state = StateAuth
+	m.auth = ui.NewAuthModel(m.cfg.DataDir, m.effectiveMSAClientID(), m.accounts)
+	m.auth.SetSize(m.width, m.height)
+	return m.auth.Init()
+}
+
+func (m *Model) validateMSAccessToken(ctx context.Context, acc *core.Account) error {
+	return api.NewAuthClient(m.effectiveMSAClientID()).ValidateMinecraftToken(ctx, acc.AccessToken)
+}
+
+func (m *Model) checkActiveSessionCmd() tea.Cmd {
+	return func() tea.Msg {
+		acc := m.accounts.GetActive()
+		if acc == nil || acc.Type != core.AccountTypeMSA {
+			return ui.ActiveSessionCheckResult{Status: ui.ActiveSessionNotApplicable}
+		}
+		if acc.IsExpired() {
+			return ui.ActiveSessionCheckResult{Status: ui.ActiveSessionInvalid}
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+		defer cancel()
+		err := m.validateMSAccessToken(ctx, acc)
+		if errors.Is(err, api.ErrMinecraftSessionInvalid) {
+			return ui.ActiveSessionCheckResult{Status: ui.ActiveSessionInvalid}
+		}
+		if err != nil {
+			return ui.ActiveSessionCheckResult{Status: ui.ActiveSessionUncertain, Err: err}
+		}
+		return ui.ActiveSessionCheckResult{Status: ui.ActiveSessionOK}
+	}
+}
+
+func (m *Model) gateOnlineLaunch(inst *core.Instance) tea.Cmd {
+	return func() tea.Msg {
+		acc := m.accounts.GetActive()
+		if acc == nil {
+			return ui.NavigateToAuth{}
+		}
+		switch acc.Type {
+		case core.AccountTypeOffline:
+			// No Minecraft Services token; online launch would run with an empty accessToken.
+			return ui.NavigateToLaunch{Instance: inst, Offline: true}
+		case core.AccountTypeMSA:
+			// continue below
+		default:
+			return ui.NavigateToAuth{}
+		}
+		if acc.IsExpired() {
+			return ui.SessionGateFailed{NeedAuth: true}
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		err := m.validateMSAccessToken(ctx, acc)
+		if errors.Is(err, api.ErrMinecraftSessionInvalid) {
+			return ui.SessionGateFailed{NeedAuth: true}
+		}
+		if err != nil {
+			return ui.SessionGateFailed{Err: err}
+		}
+		return ui.ProceedWithLaunch{Instance: inst}
+	}
+}
+
+func (m *Model) sessionRecheckCmd() tea.Cmd {
+	return tea.Sequence(
+		func() tea.Msg { return ui.ActiveSessionCheckStarted{} },
+		m.checkActiveSessionCmd(),
 	)
 }
 
@@ -162,7 +246,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Navigation messages
 	case ui.NavigateToHome:
 		m.state = StateHome
-		return m, m.loadInstances()
+		return m, tea.Batch(m.loadInstances(), m.sessionRecheckCmd())
 
 	case ui.NavigateToNewInstance:
 		m.state = StateNewInstance
@@ -174,24 +258,50 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		)
 
 	case ui.NavigateToLaunch:
+		if msg.Offline {
+			m.state = StateLaunch
+			m.launch = ui.NewLaunchModel(msg.Instance)
+			m.launch.SetSize(m.width, m.height)
+			return m, tea.Batch(
+				m.launch.Init(),
+				m.startLaunch(msg.Instance, true),
+			)
+		}
+		return m, m.gateOnlineLaunch(msg.Instance)
+
+	case ui.ProceedWithLaunch:
 		m.state = StateLaunch
 		m.launch = ui.NewLaunchModel(msg.Instance)
 		m.launch.SetSize(m.width, m.height)
 		return m, tea.Batch(
 			m.launch.Init(),
-			m.startLaunch(msg.Instance, msg.Offline),
+			m.startLaunch(msg.Instance, false),
 		)
 
-	case ui.NavigateToAuth:
-		m.state = StateAuth
-		clientID := m.cfg.MSAClientID
-		if clientID == "" {
-			// Fallback or error? For now use a placeholder to allow testing
-			clientID = "YOUR_CLIENT_ID"
+	case ui.SessionGateFailed:
+		if msg.NeedAuth {
+			return m, m.prepareAuthScreen()
 		}
-		m.auth = ui.NewAuthModel(m.cfg.DataDir, clientID, m.accounts)
-		m.auth.SetSize(m.width, m.height)
-		return m, m.auth.Init()
+		m.state = StateHome
+		if m.launchCtxCancel != nil {
+			m.launchCtxCancel()
+			m.launchCtxCancel = nil
+		}
+		m.launch = nil
+		m.launchStatusChan = nil
+		m.home.SetTransientBanner("Could not verify Microsoft session. Check your connection or press [o] for offline.")
+		return m, tea.Batch(m.loadInstances(), m.sessionRecheckCmd())
+
+	case ui.ActiveSessionCheckStarted:
+		m.home.SetSessionCheckStarted()
+		return m, nil
+
+	case ui.ActiveSessionCheckResult:
+		m.home.ApplyActiveSessionCheckResult(msg)
+		return m, nil
+
+	case ui.NavigateToAuth:
+		return m, m.prepareAuthScreen()
 
 	case ui.DeleteInstance:
 		if msg.Instance != nil {
@@ -205,7 +315,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.state = StateHome
-		return m, m.loadInstances()
+		return m, tea.Batch(m.loadInstances(), m.sessionRecheckCmd())
 
 	// Launch status updates - continue subscription
 	case ui.LaunchStatusUpdate:
@@ -226,7 +336,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.launchStatusChan = nil
 		// Return to home
 		m.state = StateHome
-		return m, m.loadInstances()
+		return m, tea.Batch(m.loadInstances(), m.sessionRecheckCmd())
 
 	// Launch complete - clean up
 	case ui.LaunchComplete:
@@ -247,7 +357,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ui.RetryLaunch:
 		if m.launch != nil {
 			inst := m.launch.GetInstance()
-			return m, m.startLaunch(inst, msg.Offline)
+			if msg.Offline {
+				return m, m.startLaunch(inst, true)
+			}
+			return m, m.gateOnlineLaunch(inst)
 		}
 		return m, nil
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/quasar/mctui/internal/core"
 	"github.com/quasar/mctui/internal/launch"
 	"github.com/quasar/mctui/internal/loader"
+	"github.com/quasar/mctui/internal/mods"
 	"github.com/quasar/mctui/internal/ui"
 )
 
@@ -40,6 +41,7 @@ type Model struct {
 	home   *ui.HomeModel
 	wizard *ui.WizardModel
 	launch *ui.LaunchModel
+	mods   *ui.ModsModel
 	auth   *ui.AuthModel
 
 	// Core services
@@ -47,6 +49,7 @@ type Model struct {
 	instances *core.InstanceManager
 	accounts  *core.AccountManager
 	mojang    *api.MojangClient
+	modrinth  *api.ModrinthClient
 
 	// Launch state
 	launchStatusChan chan launch.Status
@@ -107,6 +110,7 @@ func New() *Model {
 		instances: instances,
 		accounts:  accounts,
 		mojang:    api.NewMojangClient(cfg.DataDir),
+		modrinth:  api.NewModrinthClient(),
 		keys:      defaultKeyMap(),
 	}
 }
@@ -133,8 +137,17 @@ func (m *Model) effectiveMSAClientID() string {
 func (m *Model) prepareAuthScreen() tea.Cmd {
 	m.state = StateAuth
 	m.auth = ui.NewAuthModel(m.cfg.DataDir, m.effectiveMSAClientID(), m.accounts)
-	m.auth.SetSize(m.width, m.height)
+	cw, ch := m.contentSize()
+	m.auth.SetSize(cw, ch)
 	return m.auth.Init()
+}
+
+// contentSize is the drawable area inside [ui.AppShellStyle] for the current terminal size.
+func (m *Model) contentSize() (w, h int) {
+	if m.width <= 0 {
+		return 0, 0
+	}
+	return max(0, m.width-2*ui.AppShellPadX), max(0, m.height-2*ui.AppShellPadY)
 }
 
 func (m *Model) validateMSAccessToken(ctx context.Context, acc *core.Account) error {
@@ -202,11 +215,17 @@ func (m *Model) sessionRecheckCmd() tea.Cmd {
 }
 
 func (m *Model) loadInstances() tea.Cmd {
+	return m.loadInstancesSelecting("")
+}
+
+// loadInstancesSelecting reloads instances from disk; selectID optionally focuses that instance in the home list.
+func (m *Model) loadInstancesSelecting(selectID string) tea.Cmd {
 	return func() tea.Msg {
 		err := m.instances.Load()
 		return ui.InstancesLoaded{
 			Instances: m.instances.List(),
 			Error:     err,
+			SelectID:  selectID,
 		}
 	}
 }
@@ -235,34 +254,62 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = msg.Height
 		m.ready = true
 
-		// Propagate size to child models
-		m.home.SetSize(msg.Width, msg.Height)
+		cw, ch := m.contentSize()
+		m.home.SetSize(cw, ch)
 		if m.wizard != nil {
-			m.wizard.SetSize(msg.Width, msg.Height)
+			m.wizard.SetSize(cw, ch)
 		}
 		if m.launch != nil {
-			m.launch.SetSize(msg.Width, msg.Height)
+			m.launch.SetSize(cw, ch)
+		}
+		if m.mods != nil {
+			m.mods.SetSize(cw, ch)
+		}
+		if m.auth != nil {
+			m.auth.SetSize(cw, ch)
 		}
 
 	// Navigation messages
 	case ui.NavigateToHome:
+		if m.mods != nil {
+			m.mods.CancelPending()
+		}
 		m.state = StateHome
+		m.mods = nil
 		return m, tea.Batch(m.loadInstances(), m.sessionRecheckCmd())
+
+	case ui.NavigateToSettings:
+		m.state = StateSettings
+		cw, ch := m.contentSize()
+		m.home.SetSize(cw, ch)
+		return m, nil
 
 	case ui.NavigateToNewInstance:
 		m.state = StateNewInstance
 		m.wizard = ui.NewWizardModel(m.instances.List())
-		m.wizard.SetSize(m.width, m.height)
+		cw, ch := m.contentSize()
+		m.wizard.SetSize(cw, ch)
 		return m, tea.Batch(
 			m.wizard.Init(),
 			m.loadVersions(),
 		)
 
+	case ui.NavigateToMods:
+		if msg.Instance == nil {
+			return m, nil
+		}
+		m.state = StateMods
+		m.mods = ui.NewModsModel(msg.Instance, m.modrinth)
+		cw, ch := m.contentSize()
+		m.mods.SetSize(cw, ch)
+		return m, m.mods.Init()
+
 	case ui.NavigateToLaunch:
 		if msg.Offline {
 			m.state = StateLaunch
 			m.launch = ui.NewLaunchModel(msg.Instance, m.cfg)
-			m.launch.SetSize(m.width, m.height)
+			cw, ch := m.contentSize()
+			m.launch.SetSize(cw, ch)
 			return m, tea.Batch(
 				m.launch.Init(),
 				m.startLaunch(msg.Instance, true),
@@ -273,7 +320,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ui.ProceedWithLaunch:
 		m.state = StateLaunch
 		m.launch = ui.NewLaunchModel(msg.Instance, m.cfg)
-		m.launch.SetSize(m.width, m.height)
+		cw, ch := m.contentSize()
+		m.launch.SetSize(cw, ch)
 		return m, tea.Batch(
 			m.launch.Init(),
 			m.startLaunch(msg.Instance, false),
@@ -304,6 +352,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ui.NavigateToAuth:
 		return m, m.prepareAuthScreen()
 
+	case ui.ModInstallDoneMsg:
+		if m.mods != nil {
+			newMods, cmd := m.mods.Update(msg)
+			m.mods = newMods.(*ui.ModsModel)
+			return m, cmd
+		}
+		return m, nil
+
 	case ui.DeleteInstance:
 		if msg.Instance != nil {
 			_ = m.instances.Delete(msg.Instance.ID)
@@ -316,7 +372,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.state = StateHome
-		return m, tea.Batch(m.loadInstances(), m.sessionRecheckCmd())
+		id := msg.Instance.ID
+		return m, tea.Batch(m.loadInstancesSelecting(id), m.sessionRecheckCmd())
 
 	// Launch status updates - continue subscription
 	case ui.LaunchStatusUpdate:
@@ -374,6 +431,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.state == StateHome {
 				return m, tea.Quit
 			}
+		case key.Matches(msg, m.keys.Back):
+			if m.state == StateSettings {
+				m.state = StateHome
+				return m, tea.Batch(m.loadInstances(), m.sessionRecheckCmd())
+			}
 		}
 	}
 
@@ -401,6 +463,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.launch != nil {
 			newLaunch, cmd := m.launch.Update(msg)
 			m.launch = newLaunch.(*ui.LaunchModel)
+			cmds = append(cmds, cmd)
+		}
+	case StateMods:
+		if m.mods != nil {
+			newMods, cmd := m.mods.Update(msg)
+			m.mods = newMods.(*ui.ModsModel)
 			cmds = append(cmds, cmd)
 		}
 	}
@@ -443,8 +511,39 @@ func (m *Model) startLaunch(inst *core.Instance, offline bool) tea.Cmd {
 			}
 		}
 
-		// Start launcher in goroutine
+		// Start launcher in goroutine (starter Fabric mods first if requested, with progress on this screen)
 		go func() {
+			if loader.ParseKind(inst.Loader) == loader.KindFabric && inst.InstallStarterFabricMods {
+				if mods.StarterFabricModsComplete(inst) {
+					inst.InstallStarterFabricMods = false
+					_ = m.instances.Update(inst)
+				} else {
+					svc := mods.NewService(m.modrinth)
+					err := svc.InstallStarterFabricMods(ctx, inst, func(i, total int, label string) {
+						var p float64
+						if total > 0 {
+							p = float64(i) / float64(total) * 0.12
+						}
+						m.launchStatusChan <- launch.Status{
+							Step:     "Installing starter mods",
+							Message:  fmt.Sprintf("Downloading %s (%d/%d). Slow connections may take several minutes.", label, i+1, total),
+							Progress: p,
+						}
+					})
+					if err != nil {
+						m.launchStatusChan <- launch.Status{
+							Step:    "Installing starter mods",
+							Message: err.Error(),
+							Error:   err,
+						}
+						close(m.launchStatusChan)
+						return
+					}
+					inst.InstallStarterFabricMods = false
+					_ = m.instances.Update(inst)
+				}
+			}
+
 			launcher := launch.NewLauncher(&launch.Options{
 				Instance:         inst,
 				VersionInfo:      details,
@@ -500,13 +599,17 @@ func (m *Model) waitForLaunchStatus() tea.Cmd {
 	}
 }
 
-// View implements tea.Model
+// View implements tea.Model. All screens go through [ui.AppShellStyle] here only — do not pad in leaf views.
 func (m *Model) View() string {
+	return ui.AppShellStyle.Render(m.shellContent())
+}
+
+// shellContent renders the full-frame body before the app shell. Add a branch for every [State] value
+// when introducing new screens so layout width/height and padding stay consistent.
+func (m *Model) shellContent() string {
 	if !m.ready {
 		return "Initializing..."
 	}
-
-	// Delegate to current view
 	switch m.state {
 	case StateHome:
 		return m.home.View()
@@ -522,7 +625,12 @@ func (m *Model) View() string {
 		if m.auth != nil {
 			return m.auth.View()
 		}
+	case StateMods:
+		if m.mods != nil {
+			return m.mods.View()
+		}
+	case StateSettings:
+		return "Settings — coming soon\n\n[esc] Back to home"
 	}
-
 	return "Unknown state"
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -260,7 +260,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ui.NavigateToLaunch:
 		if msg.Offline {
 			m.state = StateLaunch
-			m.launch = ui.NewLaunchModel(msg.Instance)
+			m.launch = ui.NewLaunchModel(msg.Instance, m.cfg)
 			m.launch.SetSize(m.width, m.height)
 			return m, tea.Batch(
 				m.launch.Init(),
@@ -271,7 +271,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case ui.ProceedWithLaunch:
 		m.state = StateLaunch
-		m.launch = ui.NewLaunchModel(msg.Instance)
+		m.launch = ui.NewLaunchModel(msg.Instance, m.cfg)
 		m.launch.SetSize(m.width, m.height)
 		return m, tea.Batch(
 			m.launch.Init(),

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -10,13 +10,13 @@ import (
 
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/quasar/mctui/internal/api"
-	"github.com/quasar/mctui/internal/config"
-	"github.com/quasar/mctui/internal/core"
-	"github.com/quasar/mctui/internal/launch"
-	"github.com/quasar/mctui/internal/loader"
-	"github.com/quasar/mctui/internal/mods"
-	"github.com/quasar/mctui/internal/ui"
+	"github.com/mctui/mctui/internal/api"
+	"github.com/mctui/mctui/internal/config"
+	"github.com/mctui/mctui/internal/core"
+	"github.com/mctui/mctui/internal/launch"
+	"github.com/mctui/mctui/internal/loader"
+	"github.com/mctui/mctui/internal/mods"
+	"github.com/mctui/mctui/internal/ui"
 )
 
 // State represents the current view/screen of the application

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,9 @@ type Config struct {
 
 	// Auth
 	MSAClientID string `json:"msaClientID"`
+
+	// LaunchLogVerbosity filters game output in the launch view: "error", "warn", or "all".
+	LaunchLogVerbosity string `json:"launchLogVerbosity,omitempty"`
 }
 
 const (
@@ -35,14 +38,15 @@ const (
 func DefaultConfig() *Config {
 	dataDir := getDefaultDataDir()
 	return &Config{
-		DataDir:       dataDir,
-		InstancesDir:  filepath.Join(dataDir, "instances"),
-		AssetsDir:     filepath.Join(dataDir, "assets"),
-		LibrariesDir:  filepath.Join(dataDir, "libraries"),
-		JVMArgs:       []string{"-Xmx2G", "-Xms512M"},
-		Theme:         "dark",
-		ShowSnapshots: false,
-		MSAClientID:   DefaultMSAClientID,
+		DataDir:            dataDir,
+		InstancesDir:       filepath.Join(dataDir, "instances"),
+		AssetsDir:          filepath.Join(dataDir, "assets"),
+		LibrariesDir:       filepath.Join(dataDir, "libraries"),
+		JVMArgs:            []string{"-Xmx2G", "-Xms512M"},
+		Theme:              "dark",
+		ShowSnapshots:      false,
+		MSAClientID:        DefaultMSAClientID,
+		LaunchLogVerbosity: "error",
 	}
 }
 
@@ -66,6 +70,9 @@ func Load() (*Config, error) {
 	// Fallback to default ID if config file had empty string or missing field
 	if cfg.MSAClientID == "" {
 		cfg.MSAClientID = DefaultMSAClientID
+	}
+	if cfg.LaunchLogVerbosity == "" {
+		cfg.LaunchLogVerbosity = "error"
 	}
 
 	return cfg, nil

--- a/internal/core/instance.go
+++ b/internal/core/instance.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -25,6 +26,21 @@ type Instance struct {
 	// Caching fields for offline support
 	IsFullyDownloaded bool      `json:"isFullyDownloaded"` // All files downloaded and ready
 	CachedAt          time.Time `json:"cachedAt"`          // When instance was last fully cached
+	// DownloadCacheKey matches LaunchDownloadKey when isFullyDownloaded was set; used to invalidate after loader/MC changes.
+	DownloadCacheKey string `json:"downloadCacheKey,omitempty"`
+}
+
+// LaunchDownloadKey fingerprints game version, loader, and loader version for download skip logic.
+// Empty LoaderVer is normalized (e.g. vanilla); empty Loader is treated as vanilla.
+func LaunchDownloadKey(inst *Instance) string {
+	if inst == nil {
+		return ""
+	}
+	loader := strings.ToLower(strings.TrimSpace(inst.Loader))
+	if loader == "" {
+		loader = "vanilla"
+	}
+	return inst.Version + "|" + loader + "|" + strings.TrimSpace(inst.LoaderVer)
 }
 
 // InstanceManager handles instance CRUD operations

--- a/internal/core/instance.go
+++ b/internal/core/instance.go
@@ -21,13 +21,19 @@ type Instance struct {
 	JavaPath   string    `json:"javaPath"`  // Path to Java executable (optional)
 	JVMArgs    []string  `json:"jvmArgs"`   // Additional JVM arguments
 	LastPlayed time.Time `json:"lastPlayed"`
-	PlayTime   int64     `json:"playTime"` // Total playtime in seconds
+	// CreatedAt is set when the instance is first saved (wizard / Create). Used for list order when LastPlayed is zero.
+	CreatedAt time.Time `json:"createdAt,omitempty"`
+	PlayTime  int64     `json:"playTime"` // Total playtime in seconds
 
 	// Caching fields for offline support
 	IsFullyDownloaded bool      `json:"isFullyDownloaded"` // All files downloaded and ready
 	CachedAt          time.Time `json:"cachedAt"`          // When instance was last fully cached
 	// DownloadCacheKey matches LaunchDownloadKey when isFullyDownloaded was set; used to invalidate after loader/MC changes.
 	DownloadCacheKey string `json:"downloadCacheKey,omitempty"`
+
+	// InstallStarterFabricMods is true when the user opted into the default Fabric bundle at instance creation.
+	// Cleared after that bundle is installed successfully at launch (see mods package).
+	InstallStarterFabricMods bool `json:"installStarterFabricMods,omitempty"`
 }
 
 // LaunchDownloadKey fingerprints game version, loader, and loader version for download skip logic.
@@ -41,6 +47,28 @@ func LaunchDownloadKey(inst *Instance) string {
 		loader = "vanilla"
 	}
 	return inst.Version + "|" + loader + "|" + strings.TrimSpace(inst.LoaderVer)
+}
+
+// RecencyForSort picks a timestamp for ordering instances (most recent first).
+// It is the later of LastPlayed and CreatedAt (each ignored if zero). Usually LastPlayed ≥ CreatedAt.
+func RecencyForSort(inst *Instance) time.Time {
+	if inst == nil {
+		return time.Time{}
+	}
+	lp, ca := inst.LastPlayed, inst.CreatedAt
+	switch {
+	case lp.IsZero() && ca.IsZero():
+		return time.Time{}
+	case lp.IsZero():
+		return ca
+	case ca.IsZero():
+		return lp
+	default:
+		if lp.After(ca) {
+			return lp
+		}
+		return ca
+	}
 }
 
 // InstanceManager handles instance CRUD operations
@@ -117,6 +145,9 @@ func (im *InstanceManager) Create(inst *Instance) error {
 	}
 
 	inst.Path = instPath
+	if inst.CreatedAt.IsZero() {
+		inst.CreatedAt = time.Now()
+	}
 
 	// Save instance config
 	if err := im.save(inst); err != nil {

--- a/internal/core/instance_test.go
+++ b/internal/core/instance_test.go
@@ -7,6 +7,18 @@ import (
 	"time"
 )
 
+func TestLaunchDownloadKey(t *testing.T) {
+	if g, w := LaunchDownloadKey(&Instance{Version: "1.21.4", Loader: "vanilla"}), "1.21.4|vanilla|"; g != w {
+		t.Fatalf("got %q want %q", g, w)
+	}
+	if g, w := LaunchDownloadKey(&Instance{Version: "1.21.4", Loader: "", LoaderVer: ""}), "1.21.4|vanilla|"; g != w {
+		t.Fatalf("got %q want %q", g, w)
+	}
+	if g, w := LaunchDownloadKey(&Instance{Version: "1.21.4", Loader: "fabric", LoaderVer: "0.16.9"}), "1.21.4|fabric|0.16.9"; g != w {
+		t.Fatalf("got %q want %q", g, w)
+	}
+}
+
 func TestInstanceManager_CreateAndLoad(t *testing.T) {
 	// Setup temp directory
 	tmpDir := t.TempDir()

--- a/internal/core/instance_test.go
+++ b/internal/core/instance_test.go
@@ -7,6 +7,23 @@ import (
 	"time"
 )
 
+func TestRecencyForSort(t *testing.T) {
+	t1 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	if g := RecencyForSort(&Instance{LastPlayed: t2, CreatedAt: t1}); !g.Equal(t2) {
+		t.Fatalf("later of two times: got %v want %v", g, t2)
+	}
+	if g := RecencyForSort(&Instance{LastPlayed: t1, CreatedAt: t2}); !g.Equal(t2) {
+		t.Fatalf("later of two times when CreatedAt newer: got %v want %v", g, t2)
+	}
+	if g := RecencyForSort(&Instance{CreatedAt: t2}); !g.Equal(t2) {
+		t.Fatalf("CreatedAt only: got %v", g)
+	}
+	if g := RecencyForSort(&Instance{LastPlayed: t2}); !g.Equal(t2) {
+		t.Fatalf("LastPlayed only: got %v", g)
+	}
+}
+
 func TestLaunchDownloadKey(t *testing.T) {
 	if g, w := LaunchDownloadKey(&Instance{Version: "1.21.4", Loader: "vanilla"}), "1.21.4|vanilla|"; g != w {
 		t.Fatalf("got %q want %q", g, w)
@@ -36,6 +53,9 @@ func TestInstanceManager_CreateAndLoad(t *testing.T) {
 
 	if err := mgr.Create(inst); err != nil {
 		t.Fatalf("Create failed: %v", err)
+	}
+	if inst.CreatedAt.IsZero() {
+		t.Fatal("Create should set CreatedAt")
 	}
 
 	// Verify file exists

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -40,7 +40,7 @@ type Options struct {
 	UUID        string // Player UUID
 	AccessToken string // Auth Token
 	Config      *config.Config
-	
+
 	// Callbacks
 	UpdateLastPlayed func(id string) error
 	UpdateInstance   func(inst *core.Instance) error
@@ -129,7 +129,7 @@ func (l *Launcher) checkJava(ctx context.Context) error {
 	if l.opts.JavaPath != "" {
 		return nil
 	}
-	
+
 	if l.opts.Instance != nil && l.opts.Instance.JavaPath != "" {
 		if _, err := os.Stat(l.opts.Instance.JavaPath); err == nil {
 			l.opts.JavaPath = l.opts.Instance.JavaPath
@@ -343,7 +343,7 @@ func (l *Launcher) launchGame(ctx context.Context) error {
 
 	cmd := exec.CommandContext(ctx, l.opts.JavaPath, args...)
 	cmd.Dir = gameDir
-	
+
 	// Capture output
 	stdout, _ := cmd.StdoutPipe()
 	stderr, _ := cmd.StderrPipe()
@@ -368,12 +368,12 @@ func (l *Launcher) launchGame(ctx context.Context) error {
 
 	// Wait for game to finish
 	err := cmd.Wait()
-	
+
 	// Send final message
 	if err != nil {
 		return fmt.Errorf("game exited with error: %w", err)
 	}
-	
+
 	// We return nil here so the pipeline considers this step "done".
 	// The launcher will then send the "Complete" status.
 	return nil
@@ -383,23 +383,20 @@ func (l *Launcher) streamLog(r io.Reader, apiType string) {
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		text := scanner.Text()
-		
-		isImportant := apiType == "stderr" ||
-			strings.Contains(text, "[FATAL]") || 
-			strings.Contains(text, "[ERROR]") || 
-			strings.Contains(text, "[WARN]") ||
-			strings.Contains(text, "Exception") || 
-			strings.Contains(text, "Error")
-
-		if isImportant {
-			l.sendStatus(Status{
-				Step: "Launching",
-				LogLine: &LogLine{
-					Text: text,
-					Type: apiType,
-				},
-			})
+		verb := LogVerbosityError
+		if l.cfg != nil {
+			verb = ParseLaunchLogVerbosity(l.cfg.LaunchLogVerbosity)
 		}
+		if !shouldEmitGameLogLine(verb, text) {
+			continue
+		}
+		l.sendStatus(Status{
+			Step: "Playing",
+			LogLine: &LogLine{
+				Text: text,
+				Type: apiType,
+			},
+		})
 	}
 }
 

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -70,6 +70,9 @@ func NewLauncher(opts *Options, statusChan chan<- Status) *Launcher {
 
 // Launch executes the full launch pipeline
 func (l *Launcher) Launch(ctx context.Context) error {
+	// Invalidate download skip if instance version/loader changed (before any download step).
+	l.invalidateStaleDownloadCache()
+
 	steps := []struct {
 		name string
 		fn   func(context.Context) error
@@ -100,9 +103,11 @@ func (l *Launcher) Launch(ctx context.Context) error {
 
 	// Mark instance as fully downloaded for future offline launches
 	if l.opts.Instance != nil && l.opts.UpdateInstance != nil {
-		l.opts.Instance.IsFullyDownloaded = true
-		l.opts.Instance.CachedAt = time.Now()
-		_ = l.opts.UpdateInstance(l.opts.Instance)
+		inst := l.opts.Instance
+		inst.IsFullyDownloaded = true
+		inst.CachedAt = time.Now()
+		inst.DownloadCacheKey = core.LaunchDownloadKey(inst)
+		_ = l.opts.UpdateInstance(inst)
 	}
 
 	l.sendStatus(Status{
@@ -245,6 +250,26 @@ func (l *Launcher) downloadLibraries(ctx context.Context) error {
 	}
 
 	return l.performDownload(ctx, "Downloading libraries", items, 4)
+}
+
+// invalidateStaleDownloadCache clears IsFullyDownloaded when version/loader/LoaderVer changed
+// so switching e.g. vanilla→Fabric cannot skip downloading new libraries.
+func (l *Launcher) invalidateStaleDownloadCache() {
+	inst := l.opts.Instance
+	if inst == nil || l.opts.UpdateInstance == nil {
+		return
+	}
+	if !inst.IsFullyDownloaded {
+		return
+	}
+	want := core.LaunchDownloadKey(inst)
+	if inst.DownloadCacheKey == want {
+		return
+	}
+	inst.IsFullyDownloaded = false
+	inst.CachedAt = time.Time{}
+	inst.DownloadCacheKey = ""
+	_ = l.opts.UpdateInstance(inst)
 }
 
 func (l *Launcher) downloadAssets(ctx context.Context) error {

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -465,6 +465,16 @@ func (l *Launcher) buildArguments() []string {
 
 func (l *Launcher) buildClasspath() string {
 	var paths []string
+	seen := make(map[string]struct{})
+	addPath := func(p string) {
+		p = filepath.Clean(p)
+		if _, ok := seen[p]; ok {
+			return
+		}
+		seen[p] = struct{}{}
+		paths = append(paths, p)
+	}
+
 	version := l.opts.VersionInfo
 
 	// Add libraries
@@ -476,13 +486,13 @@ func (l *Launcher) buildClasspath() string {
 			continue
 		}
 		path := filepath.Join(l.cfg.LibrariesDir, lib.Downloads.Artifact.Path)
-		paths = append(paths, path)
+		addPath(path)
 	}
 
 	// Add client jar
 	clientPath := filepath.Join(l.cfg.LibrariesDir, "com", "mojang", "minecraft",
 		version.ID, fmt.Sprintf("minecraft-%s-client.jar", version.ID))
-	paths = append(paths, clientPath)
+	addPath(clientPath)
 
 	separator := ":"
 	if runtime.GOOS == "windows" {

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -14,10 +14,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/quasar/mctui/internal/config"
-	"github.com/quasar/mctui/internal/core"
-	"github.com/quasar/mctui/internal/download"
-	"github.com/quasar/mctui/internal/java"
+	"github.com/mctui/mctui/internal/config"
+	"github.com/mctui/mctui/internal/core"
+	"github.com/mctui/mctui/internal/download"
+	"github.com/mctui/mctui/internal/java"
 )
 
 // Status represents the current launch step

--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/quasar/mctui/internal/config"
-	"github.com/quasar/mctui/internal/core"
+	"github.com/mctui/mctui/internal/config"
+	"github.com/mctui/mctui/internal/core"
 )
 
 func TestLauncher_IsFullyDownloaded(t *testing.T) {

--- a/internal/launch/log_verbosity.go
+++ b/internal/launch/log_verbosity.go
@@ -1,0 +1,119 @@
+package launch
+
+import (
+	"strings"
+)
+
+// LogVerbosity controls which game log lines are surfaced in the TUI during play.
+type LogVerbosity int
+
+const (
+	LogVerbosityError LogVerbosity = iota // default: errors / stack traces only
+	LogVerbosityWarn                      // + warnings
+	LogVerbosityAll                       // full stdout / stderr
+)
+
+type logSeverity int
+
+const (
+	logSeverityDebug logSeverity = iota
+	logSeverityInfo
+	logSeverityWarn
+	logSeverityError
+)
+
+// ParseLaunchLogVerbosity maps config / JSON values to LogVerbosity.
+func ParseLaunchLogVerbosity(s string) LogVerbosity {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "warn", "warning", "warnings":
+		return LogVerbosityWarn
+	case "all", "verbose", "debug":
+		return LogVerbosityAll
+	default:
+		return LogVerbosityError
+	}
+}
+
+// ConfigString returns the value persisted in config.json.
+func (v LogVerbosity) ConfigString() string {
+	switch v {
+	case LogVerbosityWarn:
+		return "warn"
+	case LogVerbosityAll:
+		return "all"
+	default:
+		return "error"
+	}
+}
+
+// ShortLabel is a compact string for the launch screen footer.
+func (v LogVerbosity) ShortLabel() string {
+	switch v {
+	case LogVerbosityWarn:
+		return "errors+warnings"
+	case LogVerbosityAll:
+		return "all"
+	default:
+		return "errors"
+	}
+}
+
+// CycleLaunchLogVerbosity advances error → warn → all → error.
+func CycleLaunchLogVerbosity(s string) string {
+	v := ParseLaunchLogVerbosity(s)
+	switch v {
+	case LogVerbosityError:
+		return LogVerbosityWarn.ConfigString()
+	case LogVerbosityWarn:
+		return LogVerbosityAll.ConfigString()
+	default:
+		return LogVerbosityError.ConfigString()
+	}
+}
+
+func (v LogVerbosity) minSeverity() logSeverity {
+	switch v {
+	case LogVerbosityAll:
+		return logSeverityDebug
+	case LogVerbosityWarn:
+		return logSeverityWarn
+	default:
+		return logSeverityError
+	}
+}
+
+func classifyJavaLogLine(line string) logSeverity {
+	t := strings.TrimSpace(line)
+	lower := strings.ToLower(line)
+
+	if strings.Contains(lower, "[debug]") || strings.Contains(lower, "[trace]") ||
+		strings.Contains(lower, "/debug]") || strings.Contains(lower, "/trace]") ||
+		strings.Contains(lower, "[finer]") || strings.Contains(lower, "[fine]") {
+		return logSeverityDebug
+	}
+	if strings.Contains(lower, "[warn]") || strings.Contains(lower, "[warning]") ||
+		strings.Contains(lower, "/warn]") || strings.Contains(lower, "/warning]") ||
+		strings.HasPrefix(lower, "warning:") {
+		return logSeverityWarn
+	}
+	if strings.Contains(lower, "[error]") || strings.Contains(lower, "[fatal]") ||
+		strings.Contains(lower, "[severe]") || strings.Contains(lower, "/error]") ||
+		strings.Contains(lower, "/fatal]") || strings.Contains(lower, "/severe]") {
+		return logSeverityError
+	}
+	if strings.Contains(lower, "exception") || strings.Contains(lower, "caused by:") {
+		return logSeverityError
+	}
+	if strings.HasPrefix(t, "at ") && strings.Contains(line, "(") {
+		return logSeverityError
+	}
+	if strings.HasPrefix(t, "\tat ") {
+		return logSeverityError
+	}
+	return logSeverityInfo
+}
+
+func shouldEmitGameLogLine(verb LogVerbosity, line string) bool {
+	sev := classifyJavaLogLine(line)
+	return sev >= verb.minSeverity()
+}

--- a/internal/launch/log_verbosity_test.go
+++ b/internal/launch/log_verbosity_test.go
@@ -1,0 +1,56 @@
+package launch
+
+import "testing"
+
+func TestParseLaunchLogVerbosity(t *testing.T) {
+	tests := []struct {
+		in   string
+		want LogVerbosity
+	}{
+		{"", LogVerbosityError},
+		{"error", LogVerbosityError},
+		{"warn", LogVerbosityWarn},
+		{"WARNING", LogVerbosityWarn},
+		{"all", LogVerbosityAll},
+		{"verbose", LogVerbosityAll},
+	}
+	for _, tt := range tests {
+		if got := ParseLaunchLogVerbosity(tt.in); got != tt.want {
+			t.Errorf("ParseLaunchLogVerbosity(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestCycleLaunchLogVerbosity(t *testing.T) {
+	s := "error"
+	s = CycleLaunchLogVerbosity(s)
+	if ParseLaunchLogVerbosity(s) != LogVerbosityWarn {
+		t.Fatalf("after one cycle: %q", s)
+	}
+	s = CycleLaunchLogVerbosity(s)
+	if ParseLaunchLogVerbosity(s) != LogVerbosityAll {
+		t.Fatalf("after two cycles: %q", s)
+	}
+	s = CycleLaunchLogVerbosity(s)
+	if ParseLaunchLogVerbosity(s) != LogVerbosityError {
+		t.Fatalf("after three cycles: %q", s)
+	}
+}
+
+func TestShouldEmitGameLogLine(t *testing.T) {
+	if !shouldEmitGameLogLine(LogVerbosityError, "[01:00:00] [main/ERROR]: boom") {
+		t.Fatal("want error line in error mode")
+	}
+	if shouldEmitGameLogLine(LogVerbosityError, "[01:00:00] [main/WARN]: nah") {
+		t.Fatal("do not want warn line in error mode")
+	}
+	if !shouldEmitGameLogLine(LogVerbosityWarn, "[01:00:00] [main/WARN]: nah") {
+		t.Fatal("want warn line in warn mode")
+	}
+	if shouldEmitGameLogLine(LogVerbosityWarn, "Some info text without marker") {
+		t.Fatal("plain info hidden in warn mode")
+	}
+	if !shouldEmitGameLogLine(LogVerbosityAll, "Some info text without marker") {
+		t.Fatal("plain info visible in all mode")
+	}
+}

--- a/internal/loader/fabric/maven.go
+++ b/internal/loader/fabric/maven.go
@@ -1,0 +1,32 @@
+package fabric
+
+import (
+	"fmt"
+	"strings"
+)
+
+// mavenArtifactPath returns the repository-relative path (forward slashes) for a Maven coordinate.
+func mavenArtifactPath(coord string) (string, error) {
+	parts := strings.Split(coord, ":")
+	if len(parts) < 3 || len(parts) > 4 {
+		return "", fmt.Errorf("invalid maven coordinate %q", coord)
+	}
+	group := strings.ReplaceAll(parts[0], ".", "/")
+	artifact := parts[1]
+	version := parts[2]
+	classifier := ""
+	if len(parts) == 4 {
+		classifier = parts[3]
+	}
+	fileStem := artifact + "-" + version
+	if classifier != "" {
+		fileStem += "-" + classifier
+	}
+	fileStem += ".jar"
+	return fmt.Sprintf("%s/%s/%s/%s", group, artifact, version, fileStem), nil
+}
+
+// joinRepoURL joins a Maven repo base URL with a repository-relative artifact path.
+func joinRepoURL(base, rel string) string {
+	return strings.TrimSuffix(base, "/") + "/" + rel
+}

--- a/internal/loader/fabric/maven.go
+++ b/internal/loader/fabric/maven.go
@@ -5,25 +5,33 @@ import (
 	"strings"
 )
 
+// parseMavenLibraryParts splits a Gradle-style Maven coordinate: "group:artifact:version" or
+// "group:artifact:version:classifier".
+func parseMavenLibraryParts(name string) (group, artifact, version, classifier string, ok bool) {
+	parts := strings.Split(name, ":")
+	switch len(parts) {
+	case 3:
+		return parts[0], parts[1], parts[2], "", true
+	case 4:
+		return parts[0], parts[1], parts[2], parts[3], true
+	default:
+		return "", "", "", "", false
+	}
+}
+
 // mavenArtifactPath returns the repository-relative path (forward slashes) for a Maven coordinate.
 func mavenArtifactPath(coord string) (string, error) {
-	parts := strings.Split(coord, ":")
-	if len(parts) < 3 || len(parts) > 4 {
+	g, artifact, version, classifier, ok := parseMavenLibraryParts(coord)
+	if !ok {
 		return "", fmt.Errorf("invalid maven coordinate %q", coord)
 	}
-	group := strings.ReplaceAll(parts[0], ".", "/")
-	artifact := parts[1]
-	version := parts[2]
-	classifier := ""
-	if len(parts) == 4 {
-		classifier = parts[3]
-	}
+	groupPath := strings.ReplaceAll(g, ".", "/")
 	fileStem := artifact + "-" + version
 	if classifier != "" {
 		fileStem += "-" + classifier
 	}
 	fileStem += ".jar"
-	return fmt.Sprintf("%s/%s/%s/%s", group, artifact, version, fileStem), nil
+	return fmt.Sprintf("%s/%s/%s/%s", groupPath, artifact, version, fileStem), nil
 }
 
 // joinRepoURL joins a Maven repo base URL with a repository-relative artifact path.

--- a/internal/loader/fabric/merge.go
+++ b/internal/loader/fabric/merge.go
@@ -1,0 +1,106 @@
+package fabric
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/quasar/mctui/internal/core"
+)
+
+type fabricProfile struct {
+	ID           string             `json:"id"`
+	InheritsFrom string             `json:"inheritsFrom"`
+	MainClass    string             `json:"mainClass"`
+	Arguments    *core.Arguments    `json:"arguments,omitempty"`
+	Libraries    []fabricLibraryRaw `json:"libraries"`
+}
+
+type fabricLibraryRaw struct {
+	Name  string      `json:"name"`
+	URL   string      `json:"url,omitempty"`
+	SHA1  string      `json:"sha1,omitempty"`
+	Size  int64       `json:"size,omitempty"`
+	Rules []core.Rule `json:"rules,omitempty"`
+}
+
+const defaultMavenBase = "https://repo1.maven.org/maven2/"
+
+// MergeProfile merges a Fabric launcher profile JSON into Mojang parent VersionDetails.
+// The returned VersionDetails.ID is always parent.ID so the vanilla client jar path stays correct.
+func MergeProfile(parent *core.VersionDetails, profileJSON []byte) (*core.VersionDetails, error) {
+	if parent == nil {
+		return nil, fmt.Errorf("parent version details required")
+	}
+	var prof fabricProfile
+	if err := json.Unmarshal(profileJSON, &prof); err != nil {
+		return nil, fmt.Errorf("decode fabric profile: %w", err)
+	}
+	if prof.InheritsFrom != "" && prof.InheritsFrom != parent.ID {
+		return nil, fmt.Errorf("fabric profile inheritsFrom %q does not match game version %q", prof.InheritsFrom, parent.ID)
+	}
+
+	childLibs, err := normalizeFabricLibraries(prof.Libraries)
+	if err != nil {
+		return nil, err
+	}
+
+	out := *parent
+	out.Libraries = append(append([]core.Library{}, parent.Libraries...), childLibs...)
+	if prof.MainClass != "" {
+		out.MainClass = prof.MainClass
+	}
+	out.Arguments = mergeArguments(parent.Arguments, prof.Arguments)
+	return &out, nil
+}
+
+func normalizeFabricLibraries(raw []fabricLibraryRaw) ([]core.Library, error) {
+	out := make([]core.Library, 0, len(raw))
+	for _, lib := range raw {
+		base := strings.TrimSpace(lib.URL)
+		if base == "" {
+			base = defaultMavenBase
+		}
+		artifactPath, err := mavenArtifactPath(lib.Name)
+		if err != nil {
+			return nil, err
+		}
+		jarURL := joinRepoURL(base, artifactPath)
+		coreLib := core.Library{
+			Name:  lib.Name,
+			Rules: lib.Rules,
+			Downloads: &core.LibraryDownloads{
+				Artifact: &core.Artifact{
+					Path: artifactPath,
+					URL:  jarURL,
+					SHA1: lib.SHA1,
+					Size: lib.Size,
+				},
+			},
+		}
+		out = append(out, coreLib)
+	}
+	return out, nil
+}
+
+func mergeArguments(parent, child *core.Arguments) *core.Arguments {
+	if child == nil || len(child.JVM) == 0 {
+		if parent == nil {
+			return nil
+		}
+		cp := *parent
+		return &cp
+	}
+	mergedJVM := append([]interface{}{}, child.JVM...)
+	if parent != nil && len(parent.JVM) > 0 {
+		mergedJVM = append(mergedJVM, parent.JVM...)
+	}
+	out := &core.Arguments{JVM: mergedJVM}
+	if parent != nil && len(parent.Game) > 0 {
+		out.Game = append(out.Game, parent.Game...)
+	}
+	if child != nil && len(child.Game) > 0 {
+		out.Game = append(out.Game, child.Game...)
+	}
+	return out
+}

--- a/internal/loader/fabric/merge.go
+++ b/internal/loader/fabric/merge.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/quasar/mctui/internal/core"
+	"github.com/mctui/mctui/internal/core"
 )
 
 type fabricProfile struct {

--- a/internal/loader/fabric/merge.go
+++ b/internal/loader/fabric/merge.go
@@ -3,8 +3,10 @@ package fabric
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/quasar/mctui/internal/core"
 )
 
@@ -26,8 +28,14 @@ type fabricLibraryRaw struct {
 
 const defaultMavenBase = "https://repo1.maven.org/maven2/"
 
-// MergeProfile merges a Fabric launcher profile JSON into Mojang parent VersionDetails.
-// The returned VersionDetails.ID is always parent.ID so the vanilla client jar path stays correct.
+// mergeProfileCacheSchema: bump when MergeProfile output is incompatible with older cached JSON.
+const mergeProfileCacheSchema = 1
+
+func mergedProfileCacheFile(cacheDir, gameVer, loaderVer string) string {
+	return filepath.Join(cacheDir, fmt.Sprintf("fabric-merged-schema%d-%s-%s.json", mergeProfileCacheSchema, gameVer, loaderVer))
+}
+
+// MergeProfile merges Fabric profile JSON into Mojang parent VersionDetails (ID unchanged = parent.ID).
 func MergeProfile(parent *core.VersionDetails, profileJSON []byte) (*core.VersionDetails, error) {
 	if parent == nil {
 		return nil, fmt.Errorf("parent version details required")
@@ -46,12 +54,111 @@ func MergeProfile(parent *core.VersionDetails, profileJSON []byte) (*core.Versio
 	}
 
 	out := *parent
-	out.Libraries = append(append([]core.Library{}, parent.Libraries...), childLibs...)
+	mergedLibs := mergeLibrariesByMavenIdentity(parent.Libraries, childLibs)
+	mergedLibs = dedupeLibrariesByArtifactPath(mergedLibs)
+	out.Libraries = dropOW2AsmAllWhenModularPresent(mergedLibs)
 	if prof.MainClass != "" {
 		out.MainClass = prof.MainClass
 	}
 	out.Arguments = mergeArguments(parent.Arguments, prof.Arguments)
 	return &out, nil
+}
+
+// dropOW2AsmAllWhenModularPresent: asm-all vs modular asm are different coordinates but duplicate
+// org.objectweb.asm on the classpath; drop the fat jar when modular jars are present.
+func dropOW2AsmAllWhenModularPresent(libs []core.Library) []core.Library {
+	const ow2Group = "org.ow2.asm"
+	modular := false
+	for _, lib := range libs {
+		g, a, _, _, ok := parseMavenLibraryParts(lib.Name)
+		if ok && g == ow2Group && a != "asm-all" {
+			modular = true
+			break
+		}
+	}
+	if !modular {
+		return libs
+	}
+	out := make([]core.Library, 0, len(libs))
+	for _, lib := range libs {
+		g, a, _, _, ok := parseMavenLibraryParts(lib.Name)
+		if ok && g == ow2Group && a == "asm-all" {
+			continue
+		}
+		out = append(out, lib)
+	}
+	return out
+}
+
+func mavenIdentityKey(name string) (key, version string, ok bool) {
+	g, a, v, c, ok := parseMavenLibraryParts(name)
+	if !ok {
+		return "", "", false
+	}
+	return g + ":" + a + ":" + c, v, true
+}
+
+func mergeLibrariesByMavenIdentity(parent, child []core.Library) []core.Library {
+	var out []core.Library
+	at := make(map[string]int)
+	apply := func(lib core.Library) {
+		k, ver, ok := mavenIdentityKey(lib.Name)
+		if !ok {
+			out = append(out, lib)
+			return
+		}
+		i, exists := at[k]
+		if !exists {
+			at[k] = len(out)
+			out = append(out, lib)
+			return
+		}
+		_, ev, _ := mavenIdentityKey(out[i].Name)
+		if compareMavenVersions(ver, ev) > 0 {
+			out[i] = lib
+		}
+	}
+	for _, lib := range parent {
+		apply(lib)
+	}
+	for _, lib := range child {
+		apply(lib)
+	}
+	return out
+}
+
+func compareMavenVersions(a, b string) int {
+	if a == b {
+		return 0
+	}
+	va, errA := semver.NewVersion(a)
+	vb, errB := semver.NewVersion(b)
+	if errA == nil && errB == nil {
+		return va.Compare(vb)
+	}
+	return strings.Compare(a, b)
+}
+
+func dedupeLibrariesByArtifactPath(libs []core.Library) []core.Library {
+	seen := make(map[string]struct{})
+	out := make([]core.Library, 0, len(libs))
+	for _, lib := range libs {
+		if lib.Downloads == nil || lib.Downloads.Artifact == nil {
+			out = append(out, lib)
+			continue
+		}
+		p := lib.Downloads.Artifact.Path
+		if p == "" {
+			out = append(out, lib)
+			continue
+		}
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, lib)
+	}
+	return out
 }
 
 func normalizeFabricLibraries(raw []fabricLibraryRaw) ([]core.Library, error) {
@@ -99,7 +206,7 @@ func mergeArguments(parent, child *core.Arguments) *core.Arguments {
 	if parent != nil && len(parent.Game) > 0 {
 		out.Game = append(out.Game, parent.Game...)
 	}
-	if child != nil && len(child.Game) > 0 {
+	if len(child.Game) > 0 {
 		out.Game = append(out.Game, child.Game...)
 	}
 	return out

--- a/internal/loader/fabric/merge_test.go
+++ b/internal/loader/fabric/merge_test.go
@@ -1,0 +1,96 @@
+package fabric
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/quasar/mctui/internal/core"
+)
+
+func TestMergeProfile_mainClassAndLibraries(t *testing.T) {
+	parent := &core.VersionDetails{
+		ID:        "1.21.1",
+		MainClass: "net.minecraft.client.main.Main",
+		Libraries: []core.Library{
+			{Name: "parent:dep:1"},
+		},
+	}
+	parent.Libraries[0].Downloads = &core.LibraryDownloads{
+		Artifact: &core.Artifact{Path: "p/d/1/x.jar", URL: "http://example/x.jar"},
+	}
+
+	profile := `{
+  "inheritsFrom": "1.21.1",
+  "mainClass": "net.fabricmc.loader.impl.launch.knot.KnotClient",
+  "arguments": { "game": [], "jvm": ["-DFabricMcEmu= "] },
+  "libraries": [
+    {"name": "net.fabricmc:fabric-loader:0.16.0","url":"https://maven.fabricmc.net/","sha1":"abc","size":3}
+  ]
+}`
+
+	merged, err := MergeProfile(parent, []byte(profile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if merged.MainClass != "net.fabricmc.loader.impl.launch.knot.KnotClient" {
+		t.Fatalf("mainClass: %s", merged.MainClass)
+	}
+	if len(merged.Libraries) != 2 {
+		t.Fatalf("libraries len %d", len(merged.Libraries))
+	}
+	if merged.Arguments == nil || len(merged.Arguments.JVM) != 1 {
+		t.Fatalf("jvm args: %+v", merged.Arguments)
+	}
+}
+
+func TestMavenArtifactPath(t *testing.T) {
+	p, err := mavenArtifactPath("net.fabricmc:fabric-loader:0.16.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "net/fabricmc/fabric-loader/0.16.0/fabric-loader-0.16.0.jar"
+	if p != want {
+		t.Fatalf("got %q want %q", p, want)
+	}
+}
+
+func TestNormalizeFabricLibraries_url(t *testing.T) {
+	libs, err := normalizeFabricLibraries([]fabricLibraryRaw{
+		{Name: "com.google.guava:guava:33.0.0-jre", URL: "https://repo1.maven.org/maven2/", SHA1: "x", Size: 10},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(libs) != 1 || libs[0].Downloads == nil || libs[0].Downloads.Artifact == nil {
+		t.Fatalf("%+v", libs)
+	}
+	if libs[0].Downloads.Artifact.URL == "" {
+		t.Fatal("empty url")
+	}
+}
+
+func TestMergeProfileJSON_roundtrip(t *testing.T) {
+	parent := &core.VersionDetails{
+		ID:          "1.21.1",
+		MainClass:   "net.minecraft.client.main.Main",
+		AssetIndex:  core.AssetIndexRef{ID: "21"},
+		Libraries:   []core.Library{},
+		JavaVersion: core.JavaVersionReq{MajorVersion: 21},
+	}
+	profile := `{"inheritsFrom":"1.21.1","mainClass":"net.fabricmc.loader.impl.launch.knot.KnotClient","arguments":{"jvm":[]},"libraries":[]}`
+	merged, err := MergeProfile(parent, []byte(profile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(merged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back core.VersionDetails
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back.ID != parent.ID {
+		t.Fatalf("ID changed to %s (caller should set after merge if needed)", back.ID)
+	}
+}

--- a/internal/loader/fabric/merge_test.go
+++ b/internal/loader/fabric/merge_test.go
@@ -2,6 +2,7 @@ package fabric
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/quasar/mctui/internal/core"
@@ -66,6 +67,89 @@ func TestNormalizeFabricLibraries_url(t *testing.T) {
 	}
 	if libs[0].Downloads.Artifact.URL == "" {
 		t.Fatal("empty url")
+	}
+}
+
+func TestDropOW2AsmAllWhenModularPresent_dropsFatJar(t *testing.T) {
+	parent := []core.Library{
+		{Name: "org.ow2.asm:asm-all:5.2", Downloads: &core.LibraryDownloads{Artifact: &core.Artifact{Path: "o/a/5/asm-all-5.2.jar"}}},
+		{Name: "com.mojang:foo:1", Downloads: &core.LibraryDownloads{Artifact: &core.Artifact{Path: "f.jar"}}},
+	}
+	fabric := []core.Library{
+		{Name: "org.ow2.asm:asm:9.6", Downloads: &core.LibraryDownloads{Artifact: &core.Artifact{Path: "o/a/9/asm-9.6.jar"}}},
+	}
+	merged := dropOW2AsmAllWhenModularPresent(append(append([]core.Library{}, parent...), fabric...))
+	if len(merged) != 2 {
+		t.Fatalf("want 2 libs after dropping asm-all, got %d", len(merged))
+	}
+	for _, lib := range merged {
+		if strings.Contains(lib.Name, "asm-all") {
+			t.Fatalf("asm-all should be removed: %q", lib.Name)
+		}
+	}
+}
+
+func TestMergeLibrariesByMavenIdentity_higherVersionWins(t *testing.T) {
+	parent := []core.Library{
+		{Name: "org.ow2.asm:asm:9.6"},
+		{Name: "com.mojang:foo:1"},
+	}
+	child := []core.Library{
+		{Name: "org.ow2.asm:asm:9.7.1"},
+		{Name: "net.fabricmc:fabric-loader:1"},
+	}
+	out := mergeLibrariesByMavenIdentity(parent, child)
+	if len(out) != 3 {
+		t.Fatalf("want 3 libs, got %d: %+v", len(out), out)
+	}
+	var asmName string
+	for _, lib := range out {
+		if strings.HasPrefix(lib.Name, "org.ow2.asm:asm:") {
+			asmName = lib.Name
+			break
+		}
+	}
+	if asmName != "org.ow2.asm:asm:9.7.1" {
+		t.Fatalf("expected child asm version to win, got %q", asmName)
+	}
+}
+
+func TestMergeLibrariesByMavenIdentity_classifierIsSeparateSlot(t *testing.T) {
+	parent := []core.Library{{Name: "g:a:1:linux"}}
+	child := []core.Library{{Name: "g:a:2:osx"}}
+	out := mergeLibrariesByMavenIdentity(parent, child)
+	if len(out) != 2 {
+		t.Fatalf("want 2 (different classifiers), got %d", len(out))
+	}
+}
+
+func TestMergeLibrariesByMavenIdentity_childDoesNotDowngrade(t *testing.T) {
+	parent := []core.Library{{Name: "org.ow2.asm:asm:9.7.1"}}
+	child := []core.Library{{Name: "org.ow2.asm:asm:9.6"}}
+	out := mergeLibrariesByMavenIdentity(parent, child)
+	if len(out) != 1 || out[0].Name != "org.ow2.asm:asm:9.7.1" {
+		t.Fatalf("parent version should be kept: %+v", out)
+	}
+}
+
+func TestDedupeLibrariesByArtifactPath(t *testing.T) {
+	libs := []core.Library{
+		{Name: "a:1:1", Downloads: &core.LibraryDownloads{Artifact: &core.Artifact{Path: "x/y/z.jar"}}},
+		{Name: "b:2:2", Downloads: &core.LibraryDownloads{Artifact: &core.Artifact{Path: "x/y/z.jar"}}},
+	}
+	out := dedupeLibrariesByArtifactPath(libs)
+	if len(out) != 1 || out[0].Name != "a:1:1" {
+		t.Fatalf("got %+v", out)
+	}
+}
+
+func TestDropOW2AsmAllWhenModularPresent_keepsAsmAllIfAlone(t *testing.T) {
+	libs := []core.Library{
+		{Name: "org.ow2.asm:asm-all:5.2"},
+	}
+	out := dropOW2AsmAllWhenModularPresent(libs)
+	if len(out) != 1 {
+		t.Fatalf("got %d", len(out))
 	}
 }
 

--- a/internal/loader/fabric/merge_test.go
+++ b/internal/loader/fabric/merge_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/quasar/mctui/internal/core"
+	"github.com/mctui/mctui/internal/core"
 )
 
 func TestMergeProfile_mainClassAndLibraries(t *testing.T) {

--- a/internal/loader/fabric/resolve.go
+++ b/internal/loader/fabric/resolve.go
@@ -1,0 +1,150 @@
+package fabric
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/quasar/mctui/internal/api"
+	"github.com/quasar/mctui/internal/core"
+)
+
+const metaBase = "https://meta.fabricmc.net"
+
+var metaHTTP = &http.Client{Timeout: 60 * time.Second}
+
+type loaderMetaEntry struct {
+	Loader struct {
+		Version string `json:"version"`
+		Stable  bool   `json:"stable"`
+	} `json:"loader"`
+}
+
+// ResolveVersion loads merged Fabric+Mojang version metadata for launching.
+// It may set inst.LoaderVer to the latest stable Fabric loader when empty (online only).
+func ResolveVersion(ctx context.Context, mojang *api.MojangClient, inst *core.Instance, offline bool) (*core.VersionDetails, error) {
+	if inst == nil {
+		return nil, fmt.Errorf("instance required")
+	}
+	gameVer := inst.Version
+	if gameVer == "" {
+		return nil, fmt.Errorf("instance has no Minecraft version")
+	}
+
+	loaderVer := inst.LoaderVer
+	cacheDir := mojang.VersionCacheDir()
+
+	if offline {
+		if loaderVer == "" {
+			return nil, fmt.Errorf("fabric offline needs a saved loader version; connect once after choosing Fabric")
+		}
+		cacheFile := filepath.Join(cacheDir, fmt.Sprintf("fabric-merged-%s-%s.json", gameVer, loaderVer))
+		data, err := os.ReadFile(cacheFile)
+		if err != nil {
+			return nil, fmt.Errorf("offline fabric launch needs cached profile %s: %w", filepath.Base(cacheFile), err)
+		}
+		var details core.VersionDetails
+		if err := json.Unmarshal(data, &details); err != nil {
+			return nil, fmt.Errorf("read fabric cache: %w", err)
+		}
+		return &details, nil
+	}
+
+	parent, err := mojang.ResolveVersionDetails(ctx, gameVer, false)
+	if err != nil {
+		return nil, fmt.Errorf("vanilla version %s: %w", gameVer, err)
+	}
+
+	if loaderVer == "" {
+		v, err := pickStableLoaderVersion(ctx, gameVer)
+		if err != nil {
+			return nil, err
+		}
+		loaderVer = v
+		inst.LoaderVer = loaderVer
+	}
+
+	cacheFile := filepath.Join(cacheDir, fmt.Sprintf("fabric-merged-%s-%s.json", gameVer, loaderVer))
+	if data, err := os.ReadFile(cacheFile); err == nil {
+		var details core.VersionDetails
+		if json.Unmarshal(data, &details) == nil && details.MainClass != "" {
+			return &details, nil
+		}
+	}
+
+	profileURL := fmt.Sprintf("%s/v2/versions/loader/%s/%s/profile/json",
+		metaBase, url.PathEscape(gameVer), url.PathEscape(loaderVer))
+	profileJSON, err := fetchBytes(ctx, profileURL)
+	if err != nil {
+		return nil, fmt.Errorf("fabric profile: %w", err)
+	}
+
+	merged, err := MergeProfile(parent, profileJSON)
+	if err != nil {
+		return nil, err
+	}
+
+	merged.ID = parent.ID
+
+	if err := saveMergedCache(cacheFile, merged); err != nil {
+		log.Printf("fabric: could not save merged profile cache %s: %v", filepath.Base(cacheFile), err)
+	}
+
+	return merged, nil
+}
+
+func pickStableLoaderVersion(ctx context.Context, gameVersion string) (string, error) {
+	u := fmt.Sprintf("%s/v2/versions/loader/%s", metaBase, url.PathEscape(gameVersion))
+	body, err := fetchBytes(ctx, u)
+	if err != nil {
+		return "", fmt.Errorf("fabric loader list: %w", err)
+	}
+	var entries []loaderMetaEntry
+	if err := json.Unmarshal(body, &entries); err != nil {
+		return "", fmt.Errorf("decode fabric loader list: %w", err)
+	}
+	for _, e := range entries {
+		if e.Loader.Stable && e.Loader.Version != "" {
+			return e.Loader.Version, nil
+		}
+	}
+	if len(entries) > 0 && entries[0].Loader.Version != "" {
+		return entries[0].Loader.Version, nil
+	}
+	return "", fmt.Errorf("no fabric loader for Minecraft %s", gameVersion)
+}
+
+func fetchBytes(ctx context.Context, rawURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := metaHTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return nil, fmt.Errorf("%s: status %d: %s", rawURL, resp.StatusCode, string(b))
+	}
+	return io.ReadAll(resp.Body)
+}
+
+func saveMergedCache(path string, merged *core.VersionDetails) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(merged)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}

--- a/internal/loader/fabric/resolve.go
+++ b/internal/loader/fabric/resolve.go
@@ -27,8 +27,7 @@ type loaderMetaEntry struct {
 	} `json:"loader"`
 }
 
-// ResolveVersion loads merged Fabric+Mojang version metadata for launching.
-// It may set inst.LoaderVer to the latest stable Fabric loader when empty (online only).
+// ResolveVersion loads merged Fabric+Mojang version metadata; may set LoaderVer to latest stable Fabric (online).
 func ResolveVersion(ctx context.Context, mojang *api.MojangClient, inst *core.Instance, offline bool) (*core.VersionDetails, error) {
 	if inst == nil {
 		return nil, fmt.Errorf("instance required")
@@ -45,7 +44,7 @@ func ResolveVersion(ctx context.Context, mojang *api.MojangClient, inst *core.In
 		if loaderVer == "" {
 			return nil, fmt.Errorf("fabric offline needs a saved loader version; connect once after choosing Fabric")
 		}
-		cacheFile := filepath.Join(cacheDir, fmt.Sprintf("fabric-merged-%s-%s.json", gameVer, loaderVer))
+		cacheFile := mergedProfileCacheFile(cacheDir, gameVer, loaderVer)
 		data, err := os.ReadFile(cacheFile)
 		if err != nil {
 			return nil, fmt.Errorf("offline fabric launch needs cached profile %s: %w", filepath.Base(cacheFile), err)
@@ -71,7 +70,7 @@ func ResolveVersion(ctx context.Context, mojang *api.MojangClient, inst *core.In
 		inst.LoaderVer = loaderVer
 	}
 
-	cacheFile := filepath.Join(cacheDir, fmt.Sprintf("fabric-merged-%s-%s.json", gameVer, loaderVer))
+	cacheFile := mergedProfileCacheFile(cacheDir, gameVer, loaderVer)
 	if data, err := os.ReadFile(cacheFile); err == nil {
 		var details core.VersionDetails
 		if json.Unmarshal(data, &details) == nil && details.MainClass != "" {

--- a/internal/loader/fabric/resolve.go
+++ b/internal/loader/fabric/resolve.go
@@ -12,8 +12,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/quasar/mctui/internal/api"
-	"github.com/quasar/mctui/internal/core"
+	"github.com/mctui/mctui/internal/api"
+	"github.com/mctui/mctui/internal/core"
 )
 
 const metaBase = "https://meta.fabricmc.net"

--- a/internal/loader/kind.go
+++ b/internal/loader/kind.go
@@ -1,0 +1,31 @@
+// Package loader resolves Minecraft version metadata for instances with mod loaders.
+// Each loader implementation (Fabric, future Forge/Quilt/…) lives in a subpackage.
+package loader
+
+import "strings"
+
+// Kind identifies a mod loader backend.
+type Kind string
+
+const (
+	KindVanilla Kind = "vanilla"
+	KindFabric  Kind = "fabric"
+	KindForge   Kind = "forge"
+	KindQuilt   Kind = "quilt"
+)
+
+// ParseKind normalizes instance.Instance.Loader (and empty) to a Kind.
+func ParseKind(loader string) Kind {
+	switch strings.ToLower(strings.TrimSpace(loader)) {
+	case "", "vanilla":
+		return KindVanilla
+	case "fabric":
+		return KindFabric
+	case "forge":
+		return KindForge
+	case "quilt":
+		return KindQuilt
+	default:
+		return Kind(loader)
+	}
+}

--- a/internal/loader/resolve.go
+++ b/internal/loader/resolve.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/quasar/mctui/internal/api"
-	"github.com/quasar/mctui/internal/core"
-	"github.com/quasar/mctui/internal/loader/fabric"
+	"github.com/mctui/mctui/internal/api"
+	"github.com/mctui/mctui/internal/core"
+	"github.com/mctui/mctui/internal/loader/fabric"
 )
 
 // ResolveVersionDetails returns launch-ready version metadata for an instance.

--- a/internal/loader/resolve.go
+++ b/internal/loader/resolve.go
@@ -1,0 +1,27 @@
+package loader
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/quasar/mctui/internal/api"
+	"github.com/quasar/mctui/internal/core"
+	"github.com/quasar/mctui/internal/loader/fabric"
+)
+
+// ResolveVersionDetails returns launch-ready version metadata for an instance.
+// Vanilla uses Mojang JSON only; Fabric merges Fabric's profile with the parent game version.
+func ResolveVersionDetails(ctx context.Context, mojang *api.MojangClient, inst *core.Instance, offline bool) (*core.VersionDetails, error) {
+	if mojang == nil || inst == nil {
+		return nil, fmt.Errorf("mojang client and instance are required")
+	}
+
+	switch ParseKind(inst.Loader) {
+	case KindFabric:
+		return fabric.ResolveVersion(ctx, mojang, inst, offline)
+	case KindVanilla:
+		return mojang.ResolveVersionDetails(ctx, inst.Version, offline)
+	default:
+		return nil, fmt.Errorf("mod loader %q is not supported yet (coming soon)", inst.Loader)
+	}
+}

--- a/internal/mods/catalog.go
+++ b/internal/mods/catalog.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/quasar/mctui/internal/core"
+	"github.com/mctui/mctui/internal/core"
 )
 
 const catalogFileName = ".mctui-modrinth.json"

--- a/internal/mods/catalog.go
+++ b/internal/mods/catalog.go
@@ -1,0 +1,169 @@
+package mods
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/quasar/mctui/internal/core"
+)
+
+const catalogFileName = ".mctui-modrinth.json"
+
+// ModrinthCatalog tracks Modrinth projects installed via mctui (for browse badges).
+type ModrinthCatalog struct {
+	Projects []ModrinthCatalogEntry `json:"projects"`
+}
+
+// ModrinthCatalogEntry records one installed project ↔ jar file.
+type ModrinthCatalogEntry struct {
+	ProjectID string `json:"projectId"`
+	Slug      string `json:"slug"`
+	File      string `json:"file"` // basename in mods dir
+}
+
+func catalogPath(inst *core.Instance) string {
+	if inst == nil {
+		return ""
+	}
+	return filepath.Join(ModsDir(inst), catalogFileName)
+}
+
+// LoadModrinthCatalog reads the catalog, or returns empty if missing.
+func LoadModrinthCatalog(inst *core.Instance) (*ModrinthCatalog, error) {
+	if inst == nil {
+		return &ModrinthCatalog{}, nil
+	}
+	p := catalogPath(inst)
+	data, err := os.ReadFile(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &ModrinthCatalog{}, nil
+		}
+		return nil, err
+	}
+	var c ModrinthCatalog
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("catalog: %w", err)
+	}
+	return &c, nil
+}
+
+// SaveModrinthCatalog writes the catalog atomically.
+func SaveModrinthCatalog(inst *core.Instance, c *ModrinthCatalog) error {
+	if inst == nil || c == nil {
+		return fmt.Errorf("instance and catalog required")
+	}
+	if err := os.MkdirAll(ModsDir(inst), 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return err
+	}
+	p := catalogPath(inst)
+	tmp := p + ".tmp"
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, p)
+}
+
+// RecordModrinthInstall appends or updates an entry and saves.
+func RecordModrinthInstall(inst *core.Instance, projectID, slug, fileBase string) error {
+	c, err := LoadModrinthCatalog(inst)
+	if err != nil {
+		return fmt.Errorf("read catalog: %w", err)
+	}
+	fileBase = filepath.Base(fileBase)
+	var out []ModrinthCatalogEntry
+	for _, e := range c.Projects {
+		if e.ProjectID != projectID {
+			out = append(out, e)
+		}
+	}
+	out = append(out, ModrinthCatalogEntry{
+		ProjectID: projectID,
+		Slug:      slug,
+		File:      fileBase,
+	})
+	c.Projects = out
+	return SaveModrinthCatalog(inst, c)
+}
+
+// DropCatalogEntriesForJar removes catalog rows that reference a deleted jar file (basename match).
+func DropCatalogEntriesForJar(inst *core.Instance, fileBase string) error {
+	if inst == nil {
+		return fmt.Errorf("instance required")
+	}
+	fileBase = filepath.Base(fileBase)
+	c, err := LoadModrinthCatalog(inst)
+	if err != nil {
+		return err
+	}
+	var out []ModrinthCatalogEntry
+	for _, e := range c.Projects {
+		if strings.EqualFold(e.File, fileBase) {
+			continue
+		}
+		out = append(out, e)
+	}
+	if len(out) == len(c.Projects) {
+		return nil
+	}
+	c.Projects = out
+	return SaveModrinthCatalog(inst, c)
+}
+
+// ProjectRecorded returns true if projectID is in catalog and the jar still exists on disk.
+func ProjectRecorded(c *ModrinthCatalog, jars []InstalledJar, projectID string) bool {
+	if c == nil {
+		return false
+	}
+	var wantFile string
+	for _, p := range c.Projects {
+		if p.ProjectID == projectID {
+			wantFile = p.File
+			break
+		}
+	}
+	if wantFile == "" {
+		return false
+	}
+	for _, j := range jars {
+		if strings.EqualFold(j.Name, wantFile) {
+			return true
+		}
+	}
+	return false
+}
+
+// SlugHeuristicMatch returns true if slug appears to match a jar name (manual installs).
+func SlugHeuristicMatch(jarNames []string, slug string) bool {
+	if slug == "" {
+		return false
+	}
+	slug = strings.ToLower(slug)
+	slim := strings.ReplaceAll(slug, "-", "")
+	for _, n := range jarNames {
+		low := strings.ToLower(n)
+		if strings.Contains(low, slug) || strings.Contains(strings.ReplaceAll(low, "-", ""), slim) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsModrinthProjectInstalled combines catalog + on-disk file + slug heuristic.
+func IsModrinthProjectInstalled(c *ModrinthCatalog, jars []InstalledJar, projectID, slug string) bool {
+	if ProjectRecorded(c, jars, projectID) {
+		return true
+	}
+	names := make([]string, len(jars))
+	for i := range jars {
+		names[i] = jars[i].Name
+	}
+	return SlugHeuristicMatch(names, slug)
+}

--- a/internal/mods/catalog_test.go
+++ b/internal/mods/catalog_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/quasar/mctui/internal/core"
+	"github.com/mctui/mctui/internal/core"
 )
 
 func TestSlugHeuristicMatch(t *testing.T) {

--- a/internal/mods/catalog_test.go
+++ b/internal/mods/catalog_test.go
@@ -1,0 +1,80 @@
+package mods
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/quasar/mctui/internal/core"
+)
+
+func TestSlugHeuristicMatch(t *testing.T) {
+	jars := []string{"sodium-fabric-mc1.21.4-0.6.0.jar"}
+	if !SlugHeuristicMatch(jars, "sodium") {
+		t.Fatal("expected match")
+	}
+	if SlugHeuristicMatch(jars, "notthere") {
+		t.Fatal("no match")
+	}
+}
+
+func TestRecordAndProjectRecorded(t *testing.T) {
+	tmp := t.TempDir()
+	inst := &core.Instance{Path: tmp}
+	if err := EnsureModsDir(inst); err != nil {
+		t.Fatal(err)
+	}
+	if err := RecordModrinthInstall(inst, "pid1", "foo", "foo-1.jar"); err != nil {
+		t.Fatal(err)
+	}
+	c, err := LoadModrinthCatalog(inst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jars := []InstalledJar{{Name: "foo-1.jar"}}
+	if !ProjectRecorded(c, jars, "pid1") {
+		t.Fatal("expected recorded")
+	}
+	if !IsModrinthProjectInstalled(c, jars, "pid1", "foo") {
+		t.Fatal("installed")
+	}
+}
+
+func TestRecordModrinthInstallRejectsCorruptCatalog(t *testing.T) {
+	tmp := t.TempDir()
+	inst := &core.Instance{Path: tmp}
+	modsDir := filepath.Join(tmp, ".minecraft", "mods")
+	if err := os.MkdirAll(modsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(modsDir, catalogFileName), []byte("{"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := RecordModrinthInstall(inst, "pid", "slug", "a.jar"); err == nil {
+		t.Fatal("expected error when catalog is unreadable")
+	}
+}
+
+func TestDropCatalogEntriesForJar(t *testing.T) {
+	tmp := t.TempDir()
+	inst := &core.Instance{Path: tmp}
+	if err := EnsureModsDir(inst); err != nil {
+		t.Fatal(err)
+	}
+	if err := RecordModrinthInstall(inst, "pidA", "alpha", "alpha.jar"); err != nil {
+		t.Fatal(err)
+	}
+	if err := RecordModrinthInstall(inst, "pidB", "beta", "beta.jar"); err != nil {
+		t.Fatal(err)
+	}
+	if err := DropCatalogEntriesForJar(inst, "alpha.jar"); err != nil {
+		t.Fatal(err)
+	}
+	c, err := LoadModrinthCatalog(inst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(c.Projects) != 1 || c.Projects[0].ProjectID != "pidB" {
+		t.Fatalf("catalog after drop: %#v", c.Projects)
+	}
+}

--- a/internal/mods/installed.go
+++ b/internal/mods/installed.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/quasar/mctui/internal/core"
+	"github.com/mctui/mctui/internal/core"
 )
 
 // InstalledJar is a mod file present under the instance mods directory.

--- a/internal/mods/installed.go
+++ b/internal/mods/installed.go
@@ -1,0 +1,76 @@
+package mods
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/quasar/mctui/internal/core"
+)
+
+// InstalledJar is a mod file present under the instance mods directory.
+type InstalledJar struct {
+	Name string // file name only
+	Path string // absolute path
+	Size int64
+}
+
+// ListInstalledJars returns .jar files directly in ModsDir (not subfolders), sorted by name.
+func ListInstalledJars(inst *core.Instance) ([]InstalledJar, error) {
+	if inst == nil {
+		return nil, fmt.Errorf("instance required")
+	}
+	dir := ModsDir(inst)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("mods folder: %w", err)
+	}
+	var out []InstalledJar
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.EqualFold(filepath.Ext(name), ".jar") {
+			continue
+		}
+		abs := filepath.Join(dir, name)
+		fi, err := e.Info()
+		if err != nil {
+			continue
+		}
+		out = append(out, InstalledJar{Name: name, Path: abs, Size: fi.Size()})
+	}
+	sort.Slice(out, func(i, j int) bool { return strings.ToLower(out[i].Name) < strings.ToLower(out[j].Name) })
+	return out, nil
+}
+
+// EnsureModsDir creates the mods directory if missing.
+func EnsureModsDir(inst *core.Instance) error {
+	if inst == nil {
+		return fmt.Errorf("instance required")
+	}
+	dir := ModsDir(inst)
+	return os.MkdirAll(dir, 0755)
+}
+
+// RemoveInstalledJar deletes a jar from the instance mods folder (top-level only).
+func RemoveInstalledJar(inst *core.Instance, baseName string) error {
+	if inst == nil {
+		return fmt.Errorf("instance required")
+	}
+	baseName = filepath.Base(baseName)
+	if !strings.EqualFold(filepath.Ext(baseName), ".jar") {
+		return fmt.Errorf("not a .jar file")
+	}
+	path := filepath.Join(ModsDir(inst), baseName)
+	if st, err := os.Stat(path); err != nil || st.IsDir() {
+		return fmt.Errorf("mod file not found")
+	}
+	return os.Remove(path)
+}

--- a/internal/mods/installed_test.go
+++ b/internal/mods/installed_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/quasar/mctui/internal/core"
+	"github.com/mctui/mctui/internal/core"
 )
 
 func TestListInstalledJars(t *testing.T) {

--- a/internal/mods/installed_test.go
+++ b/internal/mods/installed_test.go
@@ -1,0 +1,37 @@
+package mods
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/quasar/mctui/internal/core"
+)
+
+func TestListInstalledJars(t *testing.T) {
+	tmp := t.TempDir()
+	mc := filepath.Join(tmp, ".minecraft", "mods")
+	if err := os.MkdirAll(mc, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mc, "b-mod.jar"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mc, "a-mod.jar"), []byte("yy"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mc, "readme.txt"), []byte("z"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	inst := &core.Instance{Path: tmp}
+	got, err := ListInstalledJars(inst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len %d", len(got))
+	}
+	if got[0].Name != "a-mod.jar" || got[1].Name != "b-mod.jar" {
+		t.Fatalf("%v", got)
+	}
+}

--- a/internal/mods/search.go
+++ b/internal/mods/search.go
@@ -1,0 +1,11 @@
+package mods
+
+import "strings"
+
+// SearchIndex picks Modrinth's sort index: downloads for browse (empty query), relevance when searching.
+func SearchIndex(query string) string {
+	if strings.TrimSpace(query) == "" {
+		return "downloads"
+	}
+	return "relevance"
+}

--- a/internal/mods/search_test.go
+++ b/internal/mods/search_test.go
@@ -1,0 +1,15 @@
+package mods
+
+import "testing"
+
+func TestSearchIndex(t *testing.T) {
+	if g, w := SearchIndex(""), "downloads"; g != w {
+		t.Fatalf("empty: got %q want %q", g, w)
+	}
+	if g, w := SearchIndex("   "), "downloads"; g != w {
+		t.Fatalf("whitespace: got %q want %q", g, w)
+	}
+	if g, w := SearchIndex("sodium"), "relevance"; g != w {
+		t.Fatalf("query: got %q want %q", g, w)
+	}
+}

--- a/internal/mods/service.go
+++ b/internal/mods/service.go
@@ -9,9 +9,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/quasar/mctui/internal/api"
-	"github.com/quasar/mctui/internal/core"
-	"github.com/quasar/mctui/internal/download"
+	"github.com/mctui/mctui/internal/api"
+	"github.com/mctui/mctui/internal/core"
+	"github.com/mctui/mctui/internal/download"
 )
 
 // Service wires Modrinth API calls to instance paths and download execution.

--- a/internal/mods/service.go
+++ b/internal/mods/service.go
@@ -1,0 +1,100 @@
+// Package mods orchestrates Modrinth discovery and installs into instance folders.
+// UI and HTTP types stay in internal/api; this layer encodes launcher-specific rules (Fabric + game version).
+package mods
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/quasar/mctui/internal/api"
+	"github.com/quasar/mctui/internal/core"
+	"github.com/quasar/mctui/internal/download"
+)
+
+// Service wires Modrinth API calls to instance paths and download execution.
+type Service struct {
+	Modrinth *api.ModrinthClient
+}
+
+// NewService returns a mod orchestration service. Modrinth must be non-nil.
+func NewService(m *api.ModrinthClient) *Service {
+	return &Service{Modrinth: m}
+}
+
+// ModsDir is the standard Fabric/Vanilla mods folder for an instance.
+func ModsDir(inst *core.Instance) string {
+	if inst == nil {
+		return ""
+	}
+	return filepath.Join(inst.Path, ".minecraft", "mods")
+}
+
+// SearchFabricMods queries Modrinth for mods compatible with the instance's Minecraft version and Fabric.
+func (s *Service) SearchFabricMods(ctx context.Context, inst *core.Instance, query string, offset int) (*api.SearchResult, error) {
+	if s == nil || s.Modrinth == nil {
+		return nil, fmt.Errorf("modrinth client required")
+	}
+	if inst == nil {
+		return nil, fmt.Errorf("instance required")
+	}
+	if inst.Version == "" {
+		return nil, fmt.Errorf("instance has no Minecraft version")
+	}
+	q := strings.TrimSpace(query)
+	return s.Modrinth.Search(ctx, api.SearchOptions{
+		Query:       q,
+		Index:       SearchIndex(query),
+		Offset:      offset,
+		Limit:       20,
+		Loaders:     []string{"fabric"},
+		GameVersion: inst.Version,
+		ProjectType: "mod",
+	})
+}
+
+// InstallFabricMod resolves the best matching Fabric file for projectID and downloads it into inst.mods.
+func (s *Service) InstallFabricMod(ctx context.Context, inst *core.Instance, projectID string) (string, error) {
+	if s == nil || s.Modrinth == nil {
+		return "", fmt.Errorf("modrinth client required")
+	}
+	if inst == nil {
+		return "", fmt.Errorf("instance required")
+	}
+	if inst.Version == "" {
+		return "", fmt.Errorf("instance has no Minecraft version")
+	}
+	versions, err := s.Modrinth.GetProjectVersions(ctx, projectID, []string{"fabric"}, []string{inst.Version})
+	if err != nil {
+		return "", err
+	}
+	pv := PickBestFabricVersion(versions)
+	if pv == nil {
+		return "", fmt.Errorf("no Fabric version for Minecraft %s", inst.Version)
+	}
+	file := PrimaryJar(pv)
+	if file == nil || file.URL == "" {
+		return "", fmt.Errorf("no downloadable .jar for %s", pv.VersionNumber)
+	}
+	dir := ModsDir(inst)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("mods dir: %w", err)
+	}
+	dest := filepath.Join(dir, file.Filename)
+	mgr := download.NewManager(2)
+	result, err := mgr.Download(ctx, []download.Item{{
+		URL:  file.URL,
+		Path: dest,
+		SHA1: file.Hashes.SHA1,
+		Size: file.Size,
+	}}, nil)
+	if err != nil {
+		return "", err
+	}
+	if result.Failed > 0 {
+		return "", fmt.Errorf("download failed")
+	}
+	return dest, nil
+}

--- a/internal/mods/starter.go
+++ b/internal/mods/starter.go
@@ -1,0 +1,84 @@
+package mods
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/quasar/mctui/internal/core"
+)
+
+// starterFabricMod is one Modrinth project (slug works with the v2 project API).
+// Order matters: Fabric API must load before dependent mods.
+type starterFabricMod struct {
+	slug  string
+	label string
+}
+
+// StarterFabricModsDefault is the default “basic Fabric” set for new instances.
+// Sodium Extra is omitted: it adds Sodium-related options (fog, particles, etc.) with
+// negligible extra performance cost vs Sodium; users can add it from Modrinth if wanted.
+var starterFabricModsDefault = []starterFabricMod{
+	{slug: "fabric-api", label: "Fabric API"},
+	{slug: "modmenu", label: "Mod Menu"},
+	{slug: "sodium", label: "Sodium"},
+	{slug: "lithium", label: "Lithium"},
+}
+
+// StarterFabricModsComplete reports whether every starter mod is recorded in the catalog and its jar still exists.
+func StarterFabricModsComplete(inst *core.Instance) bool {
+	if inst == nil || inst.Path == "" {
+		return false
+	}
+	c, err := LoadModrinthCatalog(inst)
+	if err != nil || c == nil {
+		return false
+	}
+	for _, sm := range starterFabricModsDefault {
+		ok := false
+		for _, e := range c.Projects {
+			if !strings.EqualFold(e.Slug, sm.slug) {
+				continue
+			}
+			p := filepath.Join(ModsDir(inst), filepath.Base(e.File))
+			if st, err := os.Stat(p); err == nil && !st.IsDir() {
+				ok = true
+			}
+			break
+		}
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// StarterInstallProgress is called before each mod download (index is 0-based).
+type StarterInstallProgress func(index, total int, label string)
+
+// InstallStarterFabricMods installs the default Fabric starter set (Fabric API, Mod Menu, Sodium, Lithium).
+// If progress is non-nil, it is invoked before each mod with the human-readable label.
+func (s *Service) InstallStarterFabricMods(ctx context.Context, inst *core.Instance, progress StarterInstallProgress) error {
+	if s == nil {
+		return fmt.Errorf("mods service required")
+	}
+	if inst == nil || inst.Path == "" {
+		return fmt.Errorf("instance with path required")
+	}
+	total := len(starterFabricModsDefault)
+	for i, sm := range starterFabricModsDefault {
+		if progress != nil {
+			progress(i, total, sm.label)
+		}
+		path, err := s.InstallFabricMod(ctx, inst, sm.slug)
+		if err != nil {
+			return fmt.Errorf("%s: %w", sm.label, err)
+		}
+		if err := RecordModrinthInstall(inst, sm.slug, sm.slug, filepath.Base(path)); err != nil {
+			return fmt.Errorf("%s (catalog): %w", sm.label, err)
+		}
+	}
+	return nil
+}

--- a/internal/mods/starter.go
+++ b/internal/mods/starter.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/quasar/mctui/internal/core"
+	"github.com/mctui/mctui/internal/core"
 )
 
 // starterFabricMod is one Modrinth project (slug works with the v2 project API).

--- a/internal/mods/starter_test.go
+++ b/internal/mods/starter_test.go
@@ -1,0 +1,26 @@
+package mods
+
+import (
+	"testing"
+
+	"github.com/quasar/mctui/internal/core"
+)
+
+func TestStarterFabricModsComplete_nil(t *testing.T) {
+	if StarterFabricModsComplete(nil) {
+		t.Fatal("nil instance should not be complete")
+	}
+	if StarterFabricModsComplete(&core.Instance{Path: "/tmp/x"}) {
+		// No catalog / jars — not complete
+		t.Fatal("instance without mods should not be complete")
+	}
+}
+
+func TestStarterFabricModsDefault_order(t *testing.T) {
+	if len(starterFabricModsDefault) < 2 {
+		t.Fatal("expected at least 2 starter mods")
+	}
+	if starterFabricModsDefault[0].slug != "fabric-api" {
+		t.Fatalf("Fabric API must be first, got %q", starterFabricModsDefault[0].slug)
+	}
+}

--- a/internal/mods/starter_test.go
+++ b/internal/mods/starter_test.go
@@ -3,7 +3,7 @@ package mods
 import (
 	"testing"
 
-	"github.com/quasar/mctui/internal/core"
+	"github.com/mctui/mctui/internal/core"
 )
 
 func TestStarterFabricModsComplete_nil(t *testing.T) {

--- a/internal/mods/version.go
+++ b/internal/mods/version.go
@@ -3,7 +3,7 @@ package mods
 import (
 	"strings"
 
-	"github.com/quasar/mctui/internal/api"
+	"github.com/mctui/mctui/internal/api"
 )
 
 // PickBestFabricVersion chooses a version to install from Modrinth's filtered list.

--- a/internal/mods/version.go
+++ b/internal/mods/version.go
@@ -1,0 +1,41 @@
+package mods
+
+import (
+	"strings"
+
+	"github.com/quasar/mctui/internal/api"
+)
+
+// PickBestFabricVersion chooses a version to install from Modrinth's filtered list.
+// The API returns versions newest-first; we prefer an explicit "release" when present.
+func PickBestFabricVersion(versions []api.ProjectVersion) *api.ProjectVersion {
+	if len(versions) == 0 {
+		return nil
+	}
+	for i := range versions {
+		if versions[i].VersionType == "release" {
+			return &versions[i]
+		}
+	}
+	return &versions[0]
+}
+
+// PrimaryJar returns the main .jar file for a project version (primary flag, else first .jar).
+func PrimaryJar(v *api.ProjectVersion) *api.VersionFile {
+	if v == nil {
+		return nil
+	}
+	for i := range v.Files {
+		f := &v.Files[i]
+		if f.Primary && strings.HasSuffix(strings.ToLower(f.Filename), ".jar") {
+			return f
+		}
+	}
+	for i := range v.Files {
+		f := &v.Files[i]
+		if strings.HasSuffix(strings.ToLower(f.Filename), ".jar") {
+			return f
+		}
+	}
+	return nil
+}

--- a/internal/mods/version_test.go
+++ b/internal/mods/version_test.go
@@ -3,7 +3,7 @@ package mods
 import (
 	"testing"
 
-	"github.com/quasar/mctui/internal/api"
+	"github.com/mctui/mctui/internal/api"
 )
 
 func TestPickBestFabricVersion(t *testing.T) {

--- a/internal/mods/version_test.go
+++ b/internal/mods/version_test.go
@@ -1,0 +1,45 @@
+package mods
+
+import (
+	"testing"
+
+	"github.com/quasar/mctui/internal/api"
+)
+
+func TestPickBestFabricVersion(t *testing.T) {
+	if PickBestFabricVersion(nil) != nil {
+		t.Fatal("expected nil")
+	}
+	vers := []api.ProjectVersion{
+		{VersionNumber: "a", VersionType: "beta"},
+		{VersionNumber: "b", VersionType: "release"},
+		{VersionNumber: "c", VersionType: "release"},
+	}
+	got := PickBestFabricVersion(vers)
+	if got == nil || got.VersionNumber != "b" {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestPrimaryJar(t *testing.T) {
+	if PrimaryJar(nil) != nil {
+		t.Fatal("expected nil")
+	}
+	v := &api.ProjectVersion{
+		Files: []api.VersionFile{
+			{Filename: "readme.txt", Primary: true},
+			{Filename: "mod-1.0.jar", Primary: false},
+		},
+	}
+	if f := PrimaryJar(v); f == nil || f.Filename != "mod-1.0.jar" {
+		t.Fatalf("got %+v", f)
+	}
+	v2 := &api.ProjectVersion{
+		Files: []api.VersionFile{
+			{Filename: "x.jar", Primary: true},
+		},
+	}
+	if f := PrimaryJar(v2); f == nil || f.Filename != "x.jar" {
+		t.Fatalf("got %+v", f)
+	}
+}

--- a/internal/ui/auth.go
+++ b/internal/ui/auth.go
@@ -11,8 +11,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	
-	"github.com/quasar/mctui/internal/api"
-	"github.com/quasar/mctui/internal/core"
+	"github.com/mctui/mctui/internal/api"
+	"github.com/mctui/mctui/internal/core"
 )
 
 type AuthState int

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -16,8 +16,8 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/quasar/mctui/internal/core"
-	"github.com/quasar/mctui/internal/loader"
+	"github.com/mctui/mctui/internal/core"
+	"github.com/mctui/mctui/internal/loader"
 )
 
 // HomeModel is the main instance list view

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -29,10 +29,25 @@ type HomeModel struct {
 	loading   bool
 	accounts  *core.AccountManager
 
+	// Microsoft session hint from background check (MSA accounts only)
+	sessionRemote sessionRemoteLine
+
+	// transientBanner is a one-line notice (e.g. session gate network error)
+	transientBanner string
+
 	// Delete confirmation state
 	confirmDelete bool
 	deleteTarget  *core.Instance
 }
+
+type sessionRemoteLine int
+
+const (
+	sessionRemoteUnset sessionRemoteLine = iota
+	sessionRemoteChecking
+	sessionRemoteInvalid
+	sessionRemoteUncertain
+)
 
 type homeKeyMap struct {
 	Launch      key.Binding
@@ -169,6 +184,52 @@ func (m *HomeModel) SetAccountManager(am *core.AccountManager) {
 	m.accounts = am
 }
 
+// SetSessionCheckStarted marks the UI as verifying the active Microsoft session.
+func (m *HomeModel) SetSessionCheckStarted() {
+	if acc := m.activeMSAAccount(); acc != nil {
+		m.sessionRemote = sessionRemoteChecking
+	}
+}
+
+// ApplyActiveSessionCheckResult updates session status from a background check.
+func (m *HomeModel) ApplyActiveSessionCheckResult(res ActiveSessionCheckResult) {
+	switch res.Status {
+	case ActiveSessionNotApplicable:
+		m.sessionRemote = sessionRemoteUnset
+	case ActiveSessionOK:
+		m.sessionRemote = sessionRemoteUnset
+	case ActiveSessionInvalid:
+		m.sessionRemote = sessionRemoteInvalid
+	case ActiveSessionUncertain:
+		m.sessionRemote = sessionRemoteUncertain
+	}
+}
+
+// SetTransientBanner shows a short notice above the footer; cleared on the next key press.
+func (m *HomeModel) SetTransientBanner(s string) {
+	m.transientBanner = s
+	m.applyListSize()
+}
+
+func (m *HomeModel) activeMSAAccount() *core.Account {
+	if m.accounts == nil {
+		return nil
+	}
+	acc := m.accounts.GetActive()
+	if acc == nil || acc.Type != core.AccountTypeMSA {
+		return nil
+	}
+	return acc
+}
+
+func (m *HomeModel) applyListSize() {
+	footerLines := 6
+	if m.transientBanner != "" {
+		footerLines++
+	}
+	m.list.SetSize(m.width, m.height-footerLines)
+}
+
 // SelectedInstance returns the currently selected instance
 func (m *HomeModel) SelectedInstance() *core.Instance {
 	if item, ok := m.list.SelectedItem().(instanceItem); ok {
@@ -181,8 +242,7 @@ func (m *HomeModel) SelectedInstance() *core.Instance {
 func (m *HomeModel) SetSize(width, height int) {
 	m.width = width
 	m.height = height
-	// Reserve space for: status (3 lines with padding) + help text (up to 2 lines)
-	m.list.SetSize(width, height-6)
+	m.applyListSize()
 }
 
 // Init implements tea.Model
@@ -200,6 +260,11 @@ func (m *HomeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
+		if m.transientBanner != "" {
+			m.transientBanner = ""
+			m.applyListSize()
+		}
+
 		// Handle delete confirmation mode
 		if m.confirmDelete {
 			switch msg.String() {
@@ -323,16 +388,46 @@ func (m *HomeModel) View() string {
 	}
 
 	var helpText string
-	authStatus := "Not logged in"
+
+	// Auth line: avoid "signed in" when Microsoft session is invalid or unverified.
+	authStatus := "Not signed in"
+	authWarn := false
 	if m.accounts != nil {
 		if acc := m.accounts.GetActive(); acc != nil {
-			authStatus = fmt.Sprintf("Logged in as %s", acc.Name)
+			switch acc.Type {
+			case core.AccountTypeMSA:
+				switch m.sessionRemote {
+				case sessionRemoteInvalid:
+					authStatus = fmt.Sprintf("%s — Microsoft sign-in required [a]", acc.Name)
+					authWarn = true
+				case sessionRemoteUncertain:
+					authStatus = fmt.Sprintf("%s — can't verify session (network?) [a]", acc.Name)
+					authWarn = true
+				case sessionRemoteChecking:
+					authStatus = fmt.Sprintf("Checking Microsoft session for %s…", acc.Name)
+				default:
+					authStatus = fmt.Sprintf("Signed in as %s", acc.Name)
+				}
+			case core.AccountTypeOffline:
+				authStatus = fmt.Sprintf("Offline: %s", acc.Name)
+			default:
+				authStatus = fmt.Sprintf("Account: %s", acc.Name)
+			}
+		}
+	}
+
+	msaNeedsSignin := false
+	if acc := m.activeMSAAccount(); acc != nil {
+		switch m.sessionRemote {
+		case sessionRemoteInvalid, sessionRemoteUncertain:
+			msaNeedsSignin = true
 		}
 	}
 
 	// Build help items based on auth status
 	var helpItems []string
-	if m.accounts != nil && m.accounts.GetActive() == nil {
+	noOnlineSession := m.accounts == nil || m.accounts.GetActive() == nil || msaNeedsSignin
+	if noOnlineSession {
 		helpItems = []string{"[↵] login & play", "[n] new", "[f] folder", "[d] delete", "[m] mods", "[s] settings", "[a] accounts", "[o] play offline", "[q] quit"}
 	} else {
 		helpItems = []string{"[↵] launch", "[n] new", "[f] folder", "[d] delete", "[m] mods", "[s] settings", "[a] accounts", "[o] play offline", "[q] quit"}
@@ -345,17 +440,24 @@ func (m *HomeModel) View() string {
 		Foreground(lipgloss.Color("#626262")).
 		Render(helpText)
 
+	statusColor := lipgloss.Color("#7C3AED")
+	if authWarn {
+		statusColor = lipgloss.Color("#FBBF24")
+	}
 	status := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#7C3AED")).
+		Foreground(statusColor).
 		Padding(1, 0).
 		Render(authStatus)
 
-	baseView := lipgloss.JoinVertical(
-		lipgloss.Left,
-		m.list.View(),
-		status,
-		help,
-	)
+	aboveStatus := []string{m.list.View()}
+	if m.transientBanner != "" {
+		aboveStatus = append(aboveStatus, lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#FBBF24")).
+			Render(m.transientBanner))
+	}
+	aboveStatus = append(aboveStatus, status, help)
+
+	baseView := lipgloss.JoinVertical(lipgloss.Left, aboveStatus...)
 
 	// Show delete confirmation overlay if needed
 	if m.confirmDelete && m.deleteTarget != nil {

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -17,6 +17,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/quasar/mctui/internal/core"
+	"github.com/quasar/mctui/internal/loader"
 )
 
 // HomeModel is the main instance list view
@@ -36,8 +37,9 @@ type HomeModel struct {
 	transientBanner string
 
 	// Delete confirmation state
-	confirmDelete bool
-	deleteTarget  *core.Instance
+	confirmDelete  bool
+	deleteTarget   *core.Instance
+	deleteFocusYes bool // which option arrows / Enter apply to (default Yes so Enter still confirms delete)
 }
 
 type sessionRemoteLine int
@@ -103,6 +105,7 @@ type instanceItem struct {
 }
 
 func (i instanceItem) Title() string { return i.instance.Name }
+
 func (i instanceItem) Description() string {
 	loader := i.instance.Loader
 	if loader == "" || loader == "vanilla" {
@@ -136,15 +139,15 @@ func formatRelativeTime(t time.Time) string {
 
 // NewHomeModel creates a new home view model
 func NewHomeModel() *HomeModel {
-	delegate := list.NewDefaultDelegate()
-	delegate.Styles.SelectedTitle = delegate.Styles.SelectedTitle.
+	base := list.NewDefaultDelegate()
+	base.Styles.SelectedTitle = base.Styles.SelectedTitle.
 		Foreground(lipgloss.Color("#7C3AED")).
 		BorderLeftForeground(lipgloss.Color("#7C3AED"))
-	delegate.Styles.SelectedDesc = delegate.Styles.SelectedDesc.
+	base.Styles.SelectedDesc = base.Styles.SelectedDesc.
 		Foreground(lipgloss.Color("#A78BFA")).
 		BorderLeftForeground(lipgloss.Color("#7C3AED"))
 
-	l := list.New([]list.Item{}, delegate, 0, 0)
+	l := list.New([]list.Item{}, &homeInstanceDelegate{DefaultDelegate: base}, 0, 0)
 	l.Title = "🎮 Minecraft Instances"
 	l.SetShowStatusBar(true)
 	l.SetFilteringEnabled(true)
@@ -163,14 +166,14 @@ func NewHomeModel() *HomeModel {
 	}
 }
 
-// SetInstances updates the instance list
-func (m *HomeModel) SetInstances(instances []*core.Instance) {
+// SetInstances updates the instance list. If selectID is non-empty, the cursor moves to that instance (usually index 0 for a new instance).
+func (m *HomeModel) SetInstances(instances []*core.Instance, selectID string) {
 	m.instances = instances
 	m.loading = false
 
-	// Sort by last played (most recent first)
+	// Sort by max(LastPlayed, CreatedAt) — newest first
 	sort.Slice(instances, func(i, j int) bool {
-		return instances[i].LastPlayed.After(instances[j].LastPlayed)
+		return core.RecencyForSort(instances[i]).After(core.RecencyForSort(instances[j]))
 	})
 
 	items := make([]list.Item, len(instances))
@@ -178,6 +181,16 @@ func (m *HomeModel) SetInstances(instances []*core.Instance) {
 		items[i] = instanceItem{instance: inst}
 	}
 	m.list.SetItems(items)
+
+	if selectID != "" {
+		for i, inst := range instances {
+			if inst.ID == selectID {
+				m.list.Select(i)
+				return
+			}
+		}
+		m.list.Select(0)
+	}
 }
 
 func (m *HomeModel) SetAccountManager(am *core.AccountManager) {
@@ -238,6 +251,15 @@ func (m *HomeModel) SelectedInstance() *core.Instance {
 	return nil
 }
 
+// instanceSupportsModsBrowser is true when the in-app Mods (Modrinth) screen applies.
+// Expand this when additional loaders are wired up the same way.
+func instanceSupportsModsBrowser(inst *core.Instance) bool {
+	if inst == nil {
+		return false
+	}
+	return loader.ParseKind(inst.Loader) == loader.KindFabric
+}
+
 // SetSize updates the dimensions of the home view
 func (m *HomeModel) SetSize(width, height int) {
 	m.width = width
@@ -255,7 +277,7 @@ func (m *HomeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case InstancesLoaded:
 		if msg.Error == nil {
-			m.SetInstances(msg.Instances)
+			m.SetInstances(msg.Instances, msg.SelectID)
 		}
 		return m, nil
 
@@ -268,11 +290,36 @@ func (m *HomeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Handle delete confirmation mode
 		if m.confirmDelete {
 			switch msg.String() {
-			case "y", "Y", "enter":
+			case "up", "left":
+				m.deleteFocusYes = true
+				return m, nil
+			case "down", "right":
+				m.deleteFocusYes = false
+				return m, nil
+			case "k":
+				m.deleteFocusYes = true
+				return m, nil
+			case "j":
+				m.deleteFocusYes = false
+				return m, nil
+			case "tab":
+				m.deleteFocusYes = !m.deleteFocusYes
+				return m, nil
+			case "y", "Y":
 				inst := m.deleteTarget
 				m.confirmDelete = false
 				m.deleteTarget = nil
 				return m, func() tea.Msg { return DeleteInstance{Instance: inst} }
+			case "enter":
+				if m.deleteFocusYes {
+					inst := m.deleteTarget
+					m.confirmDelete = false
+					m.deleteTarget = nil
+					return m, func() tea.Msg { return DeleteInstance{Instance: inst} }
+				}
+				m.confirmDelete = false
+				m.deleteTarget = nil
+				return m, nil
 			case "n", "N", "esc", "q":
 				m.confirmDelete = false
 				m.deleteTarget = nil
@@ -304,6 +351,10 @@ func (m *HomeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, func() tea.Msg { return NavigateToNewInstance{} }
 		case key.Matches(msg, m.keys.Mods):
 			if inst := m.SelectedInstance(); inst != nil {
+				if !instanceSupportsModsBrowser(inst) {
+					m.SetTransientBanner("Mods browser isn't available for this instance.")
+					return m, nil
+				}
 				return m, func() tea.Msg { return NavigateToMods{Instance: inst} }
 			}
 		case key.Matches(msg, m.keys.Settings):
@@ -316,9 +367,10 @@ func (m *HomeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case key.Matches(msg, m.keys.Delete):
 			if inst := m.SelectedInstance(); inst != nil {
-				// Show confirmation prompt
+				// Show confirmation prompt (Yes focused: Enter deletes; arrows or Tab change choice)
 				m.confirmDelete = true
 				m.deleteTarget = inst
+				m.deleteFocusYes = true
 				return m, nil
 			}
 		}
@@ -424,14 +476,18 @@ func (m *HomeModel) View() string {
 		}
 	}
 
-	// Build help items based on auth status
+	// Build help items based on auth status.
 	var helpItems []string
 	noOnlineSession := m.accounts == nil || m.accounts.GetActive() == nil || msaNeedsSignin
+	launchKey := "[↵] launch"
 	if noOnlineSession {
-		helpItems = []string{"[↵] login & play", "[n] new", "[f] folder", "[d] delete", "[m] mods", "[s] settings", "[a] accounts", "[o] play offline", "[q] quit"}
-	} else {
-		helpItems = []string{"[↵] launch", "[n] new", "[f] folder", "[d] delete", "[m] mods", "[s] settings", "[a] accounts", "[o] play offline", "[q] quit"}
+		launchKey = "[↵] login & play"
 	}
+	modsKey := "[m] mods"
+	if inst := m.SelectedInstance(); inst != nil && !instanceSupportsModsBrowser(inst) {
+		modsKey = "[m] mods (unsupported)"
+	}
+	helpItems = []string{launchKey, "[n] new", "[f] folder", "[d] delete", modsKey, "[s] settings", "[a] accounts", "[o] play offline", "[q] quit"}
 
 	// Build help text with smart item-wise wrapping
 	helpText = buildHelpText(helpItems, m.width-4)
@@ -473,10 +529,26 @@ func (m *HomeModel) View() string {
 			Foreground(lipgloss.Color("#A1A1AA")).
 			Render(fmt.Sprintf("Are you sure you want to delete \"%s\"?\nThis cannot be undone.", m.deleteTarget.Name))
 
+		yesLbl := "Yes, delete"
+		noLbl := "No, cancel"
+		yesSt := lipgloss.NewStyle().Foreground(lipgloss.Color("#626262"))
+		noSt := lipgloss.NewStyle().Foreground(lipgloss.Color("#626262"))
+		if m.deleteFocusYes {
+			yesSt = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FAFAFA"))
+		} else {
+			noSt = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FAFAFA"))
+		}
 		options := lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#626262")).
 			MarginTop(1).
-			Render("[y] Yes, delete  •  [n] No, cancel")
+			Render(lipgloss.JoinHorizontal(lipgloss.Left,
+				yesSt.Render(yesLbl),
+				lipgloss.NewStyle().Foreground(lipgloss.Color("#52525B")).Render("  ·  "),
+				noSt.Render(noLbl),
+			))
+		hint := lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#52525B")).
+			MarginTop(1).
+			Render("[↑↓←→] or Tab · [Enter] choose · [y]/[n] · Esc cancel")
 
 		promptBox := lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
@@ -488,6 +560,7 @@ func (m *HomeModel) View() string {
 				"",
 				msg,
 				options,
+				hint,
 			))
 
 		return lipgloss.Place(

--- a/internal/ui/home_delegate.go
+++ b/internal/ui/home_delegate.go
@@ -1,0 +1,125 @@
+package ui
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// Pill-style "new" badge (distinct from instance title typography).
+var (
+	newBadgeNormal = lipgloss.NewStyle().
+			Background(lipgloss.Color("#3F3F46")).
+			Foreground(lipgloss.Color("#E4E4E7")).
+			Padding(0, 1)
+
+	newBadgeSelected = lipgloss.NewStyle().
+				Background(lipgloss.Color("#6D28D9")).
+				Foreground(lipgloss.Color("#FAFAFA")).
+				Padding(0, 1)
+
+	newBadgeDimmed = lipgloss.NewStyle().
+			Background(lipgloss.Color("#27272A")).
+			Foreground(lipgloss.Color("#52525B")).
+			Padding(0, 1)
+)
+
+const titleEllipsis = "…"
+
+// homeInstanceDelegate wraps the default list delegate so never-played instances get a separate "new" badge.
+type homeInstanceDelegate struct {
+	list.DefaultDelegate
+}
+
+func (d *homeInstanceDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) {
+	ii, ok := item.(instanceItem)
+	if !ok {
+		d.DefaultDelegate.Render(w, m, index, item)
+		return
+	}
+
+	s := &d.Styles
+	name := ii.instance.Name
+	desc := ii.Description()
+	showBadge := ii.instance.LastPlayed.IsZero()
+
+	if m.Width() <= 0 {
+		return
+	}
+
+	textwidth := m.Width() - s.NormalTitle.GetPaddingLeft() - s.NormalTitle.GetPaddingRight()
+	badgeReserve := 0
+	if showBadge {
+		badgeReserve = lipgloss.Width(newBadgeNormal.Render("new")) + 1
+	}
+
+	title := ansi.Truncate(name, textwidth-badgeReserve, titleEllipsis)
+	if d.ShowDescription {
+		var lines []string
+		for i, line := range strings.Split(desc, "\n") {
+			if i >= d.Height()-1 {
+				break
+			}
+			lines = append(lines, ansi.Truncate(line, textwidth, titleEllipsis))
+		}
+		desc = strings.Join(lines, "\n")
+	}
+
+	var (
+		isSelected   = index == m.Index()
+		emptyFilter  = m.FilterState() == list.Filtering && m.FilterValue() == ""
+		isFiltered   = m.FilterState() == list.Filtering || m.FilterState() == list.FilterApplied
+		matchedRunes []int
+	)
+
+	if isFiltered {
+		matchedRunes = m.MatchesForItem(index)
+	}
+
+	joinTitle := func(titleLine string, badge lipgloss.Style) string {
+		t := titleLine
+		if showBadge {
+			return lipgloss.JoinHorizontal(lipgloss.Left, t, " ", badge.Render("new"))
+		}
+		return t
+	}
+
+	var titleOut, descOut string
+
+	switch {
+	case emptyFilter:
+		t := s.DimmedTitle.Render(title)
+		titleOut = joinTitle(t, newBadgeDimmed)
+		descOut = s.DimmedDesc.Render(desc)
+
+	case isSelected && m.FilterState() != list.Filtering:
+		if isFiltered {
+			unmatched := s.SelectedTitle.Inline(true)
+			matched := unmatched.Inherit(s.FilterMatch)
+			title = lipgloss.StyleRunes(title, matchedRunes, matched, unmatched)
+		}
+		t := s.SelectedTitle.Render(title)
+		titleOut = joinTitle(t, newBadgeSelected)
+		descOut = s.SelectedDesc.Render(desc)
+
+	default:
+		if isFiltered {
+			unmatched := s.NormalTitle.Inline(true)
+			matched := unmatched.Inherit(s.FilterMatch)
+			title = lipgloss.StyleRunes(title, matchedRunes, matched, unmatched)
+		}
+		t := s.NormalTitle.Render(title)
+		titleOut = joinTitle(t, newBadgeNormal)
+		descOut = s.NormalDesc.Render(desc)
+	}
+
+	if d.ShowDescription {
+		_, _ = fmt.Fprintf(w, "%s\n%s", titleOut, descOut)
+		return
+	}
+	_, _ = fmt.Fprintf(w, "%s", titleOut)
+}

--- a/internal/ui/launch.go
+++ b/internal/ui/launch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/bubbles/progress"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/quasar/mctui/internal/config"
 	"github.com/quasar/mctui/internal/core"
 	"github.com/quasar/mctui/internal/launch"
 )
@@ -24,6 +25,8 @@ type LaunchModel struct {
 	done     bool
 	err      error
 	logs     []string
+
+	cfg *config.Config // optional; used for log verbosity while playing
 }
 
 type stepInfo struct {
@@ -31,8 +34,8 @@ type stepInfo struct {
 	status string // pending, running, done, error
 }
 
-// NewLaunchModel creates a new launch view
-func NewLaunchModel(instance *core.Instance) *LaunchModel {
+// NewLaunchModel creates a new launch view. cfg is used for game log verbosity ([v] while playing).
+func NewLaunchModel(instance *core.Instance, cfg *config.Config) *LaunchModel {
 	p := progress.New(
 		progress.WithDefaultGradient(),
 		progress.WithWidth(50),
@@ -40,6 +43,7 @@ func NewLaunchModel(instance *core.Instance) *LaunchModel {
 
 	return &LaunchModel{
 		instance: instance,
+		cfg:      cfg,
 		progress: p,
 		steps: []stepInfo{
 			{name: "Checking Java", status: "pending"},
@@ -74,7 +78,7 @@ func (m *LaunchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case LaunchStatusUpdate:
 		m.status = msg.Status
 		m.updateSteps()
-		
+
 		if msg.Status.LogLine != nil {
 			line := fmt.Sprintf("[%s] %s", msg.Status.LogLine.Type, msg.Status.LogLine.Text)
 			m.logs = append(m.logs, line)
@@ -128,6 +132,11 @@ func (m *LaunchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "o":
 			if m.done && m.err != nil {
 				return m, func() tea.Msg { return RetryLaunch{Offline: true} }
+			}
+		case "v":
+			if m.cfg != nil && m.status.Step == "Playing" && !m.done {
+				m.cfg.LaunchLogVerbosity = launch.CycleLaunchLogVerbosity(m.cfg.LaunchLogVerbosity)
+				_ = m.cfg.Save()
 			}
 		}
 	}
@@ -187,7 +196,7 @@ func (m *LaunchModel) View() string {
 	// Status message
 	headerText := fmt.Sprintf("Launching: %s", m.instance.Name)
 	if m.status.Step == "Playing" {
-		headerText = fmt.Sprintf("Playing: %s (Standard Output)", m.instance.Name)
+		headerText = fmt.Sprintf("Playing: %s", m.instance.Name)
 	}
 	header := headerStyle.Render(headerText)
 
@@ -241,7 +250,12 @@ func (m *LaunchModel) View() string {
 	} else {
 		helpText := "[Esc] Cancel • [Ctrl+C] Quit"
 		if m.status.Step == "Playing" {
-			helpText = "[Ctrl+C] Force Quit"
+			if m.cfg != nil {
+				v := launch.ParseLaunchLogVerbosity(m.cfg.LaunchLogVerbosity)
+				helpText = fmt.Sprintf("[Ctrl+C] Force quit • [v] Logs: %s", v.ShortLabel())
+			} else {
+				helpText = "[Ctrl+C] Force quit"
+			}
 		}
 		footer = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#626262")).

--- a/internal/ui/launch.go
+++ b/internal/ui/launch.go
@@ -145,6 +145,21 @@ func (m *LaunchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *LaunchModel) updateSteps() {
+	// Dynamically add Installing starter mods (Fabric bundle before the normal pipeline)
+	if m.status.Step == "Installing starter mods" {
+		found := false
+		for _, s := range m.steps {
+			if s.name == "Installing starter mods" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			newSteps := append([]stepInfo{{name: "Installing starter mods", status: "pending"}}, m.steps...)
+			m.steps = newSteps
+		}
+	}
+
 	// Dynamically add Downloading Java if it occurs
 	if m.status.Step == "Downloading Java" {
 		found := false

--- a/internal/ui/launch.go
+++ b/internal/ui/launch.go
@@ -8,9 +8,9 @@ import (
 	"github.com/charmbracelet/bubbles/progress"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/quasar/mctui/internal/config"
-	"github.com/quasar/mctui/internal/core"
-	"github.com/quasar/mctui/internal/launch"
+	"github.com/mctui/mctui/internal/config"
+	"github.com/mctui/mctui/internal/core"
+	"github.com/mctui/mctui/internal/launch"
 )
 
 // LaunchModel shows launch progress

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -80,4 +80,34 @@ type (
 	RetryLaunch struct {
 		Offline bool
 	}
+
+	// ProceedWithLaunch continues to the launch view after online session checks pass.
+	ProceedWithLaunch struct {
+		Instance *core.Instance
+	}
+
+	// SessionGateFailed blocks online launch until the user re-authenticates or network is available.
+	SessionGateFailed struct {
+		NeedAuth bool  // missing account, locally expired, or API rejected token (401)
+		Err      error // network / server error when NeedAuth is false
+	}
+
+	// ActiveSessionCheckStarted signals a background Minecraft session check has begun.
+	ActiveSessionCheckStarted struct{}
+
+	// ActiveSessionCheckResult is the outcome of a background session verification on the home screen.
+	ActiveSessionCheckResult struct {
+		Status ActiveSessionCheckStatus
+		Err    error // set when Status is ActiveSessionUncertain
+	}
+)
+
+// ActiveSessionCheckStatus is the outcome of validating the active account against Minecraft Services.
+type ActiveSessionCheckStatus int
+
+const (
+	ActiveSessionNotApplicable ActiveSessionCheckStatus = iota // no Microsoft account to check
+	ActiveSessionOK
+	ActiveSessionInvalid
+	ActiveSessionUncertain
 )

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -2,8 +2,8 @@
 package ui
 
 import (
-	"github.com/quasar/mctui/internal/core"
-	"github.com/quasar/mctui/internal/launch"
+	"github.com/mctui/mctui/internal/core"
+	"github.com/mctui/mctui/internal/launch"
 )
 
 // Navigation messages

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -41,13 +41,16 @@ type (
 type (
 	// InstanceCreated is sent when a new instance is created
 	InstanceCreated struct {
-		Instance *core.Instance
+		Instance                 *core.Instance
+		InstallStarterFabricMods bool // mirrored from Instance.InstallStarterFabricMods (persisted in instance.json)
 	}
 
 	// InstancesLoaded is sent when instances are loaded from disk
 	InstancesLoaded struct {
 		Instances []*core.Instance
 		Error     error
+		// SelectID, if set, moves the home list cursor to that instance after refresh (e.g. newly created).
+		SelectID string
 	}
 
 	// VersionsLoaded is sent when version manifest is fetched
@@ -99,6 +102,15 @@ type (
 	ActiveSessionCheckResult struct {
 		Status ActiveSessionCheckStatus
 		Err    error // set when Status is ActiveSessionUncertain
+	}
+
+	// ModInstallDoneMsg is sent when a Modrinth mod jar install finishes or fails.
+	ModInstallDoneMsg struct {
+		ProjectID string
+		Slug      string
+		Title     string
+		Path      string
+		Err       error
 	}
 )
 

--- a/internal/ui/mods_layout.go
+++ b/internal/ui/mods_layout.go
@@ -1,0 +1,172 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Mods screen vertical layout: ModsModel.SetSize derives bubble list heights from the terminal so
+// split/stacked panes and the footer fit. See mods_layout_test.go for size invariants.
+//
+// Recommended minimum: about 32×40 (stacked mode uses more vertical chrome than split).
+// Very long status lines can still wrap past the nominal right-column budget (9 rows).
+//
+// Vertical budget for the mods screen (split + compact). Tuned against View(): outer
+// padding, header block, panel borders, chrome above lists, gaps, and help.
+const (
+	modsOuterPadY = 2 // lipgloss.NewStyle().Padding(1, 2) top + bottom on the screen block
+
+	modsHeaderLines = 4 // title + context + rule + header margin
+
+	modsPanelBorderV = 2 // rounded border top + bottom (one pane)
+
+	modsSplitInterBlockGaps = 2 // blank lines: under header, above help
+
+	// Upper bound for right-column stack above the Modrinth list (query, status, meta, hint).
+	modsRightColumnChromeLines = 9
+	// Section header under that stack (title + rule).
+	modsBrowseSectionHdrLines = 2
+
+	// Installed pane: banner (note, dialog, or toast) + section header (title + rule).
+	modsLibraryChromeLines = 5
+
+	modsHelpRuleLines = 1
+	modsHelpMargin    = 1
+)
+
+// modsScreenHelpItems is the full footer when there is enough terminal space.
+func modsScreenHelpItems() []string {
+	return []string{
+		"[tab] Installed · Search · Modrinth list",
+		"[←] [→] switch panes",
+		"[/] search · [↵] run search or download mod",
+		"Installed: Enter / d / Backspace — confirm remove ([y] or Enter)",
+		"[n] cancel dialog",
+		"[r] refresh lists · mouse wheel scrolls",
+		"[esc] back to home",
+	}
+}
+
+func modsScreenHelpItemsCompact() []string {
+	return []string{
+		"[tab] · [/] search · [↵] add · Installed [↵]/d remove · [y]/[n] dialog · [esc] home",
+	}
+}
+
+func modsScreenHelpItemsMicro() []string {
+	return []string{
+		"[tab][esc] · / search · ↵ add · Inst:↵/d del · y/n",
+	}
+}
+
+// modsHelpItemsPick selects footer text tiers so layout math matches what View renders.
+func modsHelpItemsPick(termH, termW int) []string {
+	switch {
+	case termH >= 42 && termW >= 52:
+		return modsScreenHelpItems()
+	case termH >= 22:
+		return modsScreenHelpItemsCompact()
+	default:
+		return modsScreenHelpItemsMicro()
+	}
+}
+
+// modsHelpBodyMaxWidth matches ModsModel.View: buildHelpText(..., m.width-6).
+func modsHelpBodyMaxWidth(termW int) int {
+	return max(1, termW-6)
+}
+
+func modsFooterHelpLinesFromItems(items []string, termW int) int {
+	body := buildHelpText(items, modsHelpBodyMaxWidth(termW))
+	textLines := 1
+	if body != "" {
+		textLines = strings.Count(body, "\n") + 1
+	}
+	return modsHelpRuleLines + textLines + modsHelpMargin
+}
+
+func modsFooterHelpLines(termH, termW int) int {
+	return modsFooterHelpLinesFromItems(modsHelpItemsPick(termH, termW), termW)
+}
+
+// modsLayoutSplitFixedLines is vertical space (in rows) used in split layout before list viewports and help.
+func modsLayoutSplitFixedLines() int {
+	return modsOuterPadY + modsHeaderLines + modsSplitInterBlockGaps + modsPanelBorderV +
+		modsRightColumnChromeLines + modsBrowseSectionHdrLines
+}
+
+// modsSplitListViewportHeight returns the bubble list height for each column in split layout.
+func modsSplitListViewportHeight(termH, termW int) int {
+	if termH < 1 {
+		return 1
+	}
+	fixed := modsLayoutSplitFixedLines()
+	helpH := modsFooterHelpLines(termH, termW)
+	listH := termH - fixed - helpH
+	// Footer tier matches View; only clamp list when chrome or wrapping leaves no room.
+	if fixed+helpH > termH {
+		return 1
+	}
+	if listH < 1 {
+		return 1
+	}
+	return listH
+}
+
+// modsCompactFooterItems matches footer choice in compact (stacked) layout for SetSize and View.
+func modsCompactFooterItems(termH, termW int) []string {
+	if termH >= 40 {
+		return modsHelpItemsPick(termH, termW)
+	}
+	return modsScreenHelpItemsMicro()
+}
+
+// modsCompactListHeights splits available rows between installed and Modrinth stacks.
+func modsCompactListHeights(termH, termW int) (libListH, browseListH int) {
+	if termH < 1 {
+		return 1, 1
+	}
+	helpItems := modsCompactFooterItems(termH, termW)
+	helpH := modsFooterHelpLinesFromItems(helpItems, termW)
+	libPaneShell := modsPanelBorderV + modsLibraryChromeLines
+	browsePaneShell := modsPanelBorderV + modsRightColumnChromeLines + modsBrowseSectionHdrLines
+	stackGaps := 3 // header→installed, installed→browse, browse→help
+	preList := modsOuterPadY + modsHeaderLines + stackGaps + helpH
+	room := termH - preList - libPaneShell - browsePaneShell
+	if room < 2 {
+		return 1, 1
+	}
+	// Browse list gets the lion’s share of remaining rows.
+	libListH = max(2, min(6, max(1, room/4)))
+	browseListH = room - libListH
+	if browseListH < 2 {
+		browseListH = 2
+		libListH = max(1, room-browseListH)
+	}
+	if libListH+browseListH > room {
+		browseListH = max(1, room/2)
+		libListH = max(1, room-browseListH)
+	}
+	return libListH, browseListH
+}
+
+func modPanelSectionHeader(title, accentHex string, ruleW int) string {
+	w := max(4, ruleW)
+	mark := lipgloss.NewStyle().Foreground(lipgloss.Color(accentHex)).Render("▸")
+	t := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#E4E4E7")).Render(title)
+	line := lipgloss.JoinHorizontal(lipgloss.Left, mark, " ", t)
+	r := lipgloss.NewStyle().Foreground(lipgloss.Color("#3F3F46")).Render(strings.Repeat("─", w))
+	return lipgloss.JoinVertical(lipgloss.Left, line, r)
+}
+
+func formatModHitCount(total int) string {
+	if total >= 1_000_000 {
+		return fmt.Sprintf("%.1fM", float64(total)/1_000_000)
+	}
+	if total >= 10_000 {
+		return fmt.Sprintf("%.1fK", float64(total)/1_000)
+	}
+	return fmt.Sprintf("%d", total)
+}

--- a/internal/ui/mods_layout_test.go
+++ b/internal/ui/mods_layout_test.go
@@ -1,0 +1,47 @@
+package ui
+
+import "testing"
+
+// Reasonable minimums where both split and stacked layouts fit chrome + micro footer + small lists.
+const modsLayoutTestMinH, modsLayoutTestMinW = 36, 40
+
+// Split layout: outer padding + header + gaps + pane border + right chrome + both list viewports + help.
+func TestModsLayoutSplitFitsTerminalHeight(t *testing.T) {
+	for termH := modsLayoutTestMinH; termH <= 120; termH++ {
+		for termW := modsLayoutTestMinW; termW <= 160; termW++ {
+			listH := modsSplitListViewportHeight(termH, termW)
+			helpH := modsFooterHelpLines(termH, termW)
+			total := modsLayoutSplitFixedLines() + listH + helpH
+			if total > termH {
+				t.Fatalf("split vertical budget exceeded: %dx%d used=%d (listH=%d helpH=%d fixed=%d)",
+					termW, termH, total, listH, helpH, modsLayoutSplitFixedLines())
+			}
+		}
+	}
+}
+
+// Stacked layout: fixed band + installed shell + browse shell + both list heights.
+func TestModsLayoutCompactFitsTerminalHeight(t *testing.T) {
+	for termH := modsLayoutTestMinH; termH <= 120; termH++ {
+		for termW := modsLayoutTestMinW; termW <= 160; termW++ {
+			libH, brH := modsCompactListHeights(termH, termW)
+			helpH := modsFooterHelpLinesFromItems(modsCompactFooterItems(termH, termW), termW)
+			libPane := modsPanelBorderV + modsLibraryChromeLines
+			brPane := modsPanelBorderV + modsRightColumnChromeLines + modsBrowseSectionHdrLines
+			fixed := modsOuterPadY + modsHeaderLines + 3 + helpH
+			total := fixed + libPane + libH + brPane + brH
+			if total > termH {
+				t.Fatalf("compact vertical budget exceeded: %dx%d used=%d (libH=%d brH=%d)",
+					termW, termH, total, libH, brH)
+			}
+		}
+	}
+}
+
+// Help line count must match the width ModsModel.View passes to buildHelpText.
+func TestModsHelpBodyMaxWidthMatchesView(t *testing.T) {
+	w := 53
+	if got, want := modsHelpBodyMaxWidth(w), w-6; got != want {
+		t.Fatalf("modsHelpBodyMaxWidth(%d)=%d want %d", w, got, want)
+	}
+}

--- a/internal/ui/mods_model.go
+++ b/internal/ui/mods_model.go
@@ -10,10 +10,10 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/quasar/mctui/internal/api"
-	"github.com/quasar/mctui/internal/core"
-	"github.com/quasar/mctui/internal/loader"
-	"github.com/quasar/mctui/internal/mods"
+	"github.com/mctui/mctui/internal/api"
+	"github.com/mctui/mctui/internal/core"
+	"github.com/mctui/mctui/internal/loader"
+	"github.com/mctui/mctui/internal/mods"
 )
 
 // ModsModel: left = installed, right = Modrinth (split) or stacked when narrow.

--- a/internal/ui/mods_model.go
+++ b/internal/ui/mods_model.go
@@ -1,0 +1,411 @@
+package ui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/quasar/mctui/internal/api"
+	"github.com/quasar/mctui/internal/core"
+	"github.com/quasar/mctui/internal/loader"
+	"github.com/quasar/mctui/internal/mods"
+)
+
+// ModsModel: left = installed, right = Modrinth (split) or stacked when narrow.
+type ModsModel struct {
+	inst *core.Instance
+	svc  *mods.Service
+
+	blocked bool
+
+	width         int
+	height        int
+	compactLayout bool
+
+	installed    list.Model
+	installedErr string
+	query        textinput.Model
+	results      list.Model
+
+	modsFocus modsPanel
+
+	catalog             *mods.ModrinthCatalog
+	cachedJars          []mods.InstalledJar
+	installingProjectID string
+
+	searchSeq    int
+	searchCancel context.CancelFunc
+
+	installCancel context.CancelFunc
+
+	searching    bool
+	searchErr    string
+	searchNotice string
+
+	lastTotalHits int
+
+	installing bool
+	installErr string
+	installOK  string
+
+	modsDialog    modsDialogKind
+	modsDialogJar string
+	libraryToast  string // short success line under the installed-mods pane (right pane stays Modrinth-only).
+
+	libraryListW int
+	resultsListW int
+}
+
+// NewModsModel builds a mod browser for inst.
+func NewModsModel(inst *core.Instance, client *api.ModrinthClient) *ModsModel {
+	blocked := inst == nil || loader.ParseKind(inst.Loader) != loader.KindFabric
+
+	instDel := list.NewDefaultDelegate()
+	instDel.Styles.SelectedTitle = instDel.Styles.SelectedTitle.
+		Foreground(lipgloss.Color("#FBBF24")).
+		BorderLeftForeground(lipgloss.Color("#FBBF24"))
+	instDel.Styles.SelectedDesc = instDel.Styles.SelectedDesc.
+		Foreground(lipgloss.Color("#FCD34D")).
+		BorderLeftForeground(lipgloss.Color("#FBBF24"))
+	installedList := list.New([]list.Item{}, instDel, 0, 0)
+	installedList.Title = "Installed (0)"
+	installedList.SetShowTitle(false)
+	installedList.SetShowStatusBar(true)
+	installedList.SetFilteringEnabled(false)
+	installedList.DisableQuitKeybindings()
+
+	ti := textinput.New()
+	ti.Placeholder = "Search Fabric mods, or leave empty for popular picks…"
+	ti.CharLimit = 200
+	ti.Width = 50
+	ti.PromptStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#71717A"))
+	ti.TextStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#FAFAFA"))
+
+	browseDel := list.NewDefaultDelegate()
+	browseDel.Styles.SelectedTitle = browseDel.Styles.SelectedTitle.
+		Foreground(lipgloss.Color("#10B981")).
+		BorderLeftForeground(lipgloss.Color("#10B981"))
+	browseDel.Styles.SelectedDesc = browseDel.Styles.SelectedDesc.
+		Foreground(lipgloss.Color("#6EE7B7")).
+		BorderLeftForeground(lipgloss.Color("#10B981"))
+
+	browseList := list.New([]list.Item{}, browseDel, 0, 0)
+	browseList.Title = "Modrinth"
+	browseList.SetShowTitle(false)
+	browseList.SetShowStatusBar(true)
+	browseList.SetFilteringEnabled(false)
+	browseList.DisableQuitKeybindings()
+
+	m := &ModsModel{
+		inst:      inst,
+		svc:       mods.NewService(client),
+		blocked:   blocked,
+		installed: installedList,
+		query:     ti,
+		results:   browseList,
+		modsFocus: panelBrowse,
+		catalog:   &mods.ModrinthCatalog{},
+	}
+	if !blocked {
+		_ = mods.EnsureModsDir(inst)
+		m.reloadCatalogAndJars()
+		m.refreshInstalled()
+	}
+	return m
+}
+
+func (m *ModsModel) reloadCatalogAndJars() {
+	cat, err := mods.LoadModrinthCatalog(m.inst)
+	if err != nil || cat == nil {
+		m.catalog = &mods.ModrinthCatalog{}
+	} else {
+		m.catalog = cat
+	}
+	jars, _ := mods.ListInstalledJars(m.inst)
+	m.cachedJars = jars
+}
+
+func (m *ModsModel) rowNoteForHit(hit api.SearchHit) string {
+	if m.installingProjectID == hit.ProjectID {
+		return modRowInstalling
+	}
+	if mods.IsModrinthProjectInstalled(m.catalog, m.cachedJars, hit.ProjectID, hit.Slug) {
+		return modRowInstalled
+	}
+	return ""
+}
+
+func (m *ModsModel) hitsToItems(hits []api.SearchHit) []list.Item {
+	items := make([]list.Item, 0, len(hits))
+	for _, h := range hits {
+		h := h
+		note := m.rowNoteForHit(h)
+		items = append(items, modListItem{hit: h, rowNote: note})
+	}
+	return items
+}
+
+func (m *ModsModel) rebuildBrowseBadges() {
+	raw := m.results.Items()
+	next := make([]list.Item, len(raw))
+	for i, it := range raw {
+		if li, ok := it.(modListItem); ok {
+			li.rowNote = m.rowNoteForHit(li.hit)
+			next[i] = li
+		} else {
+			next[i] = it
+		}
+	}
+	m.results.SetItems(next)
+}
+
+func (m *ModsModel) clearModsDialog() {
+	m.modsDialog = modsDialogNone
+	m.modsDialogJar = ""
+}
+
+func (m *ModsModel) syncModsDialogSelection() {
+	if m.modsDialog != modsDialogConfirmRemoveJar {
+		return
+	}
+	it, ok := m.installed.SelectedItem().(modInstalledItem)
+	if !ok || it.jar.Name != m.modsDialogJar {
+		m.clearModsDialog()
+	}
+}
+
+func (m *ModsModel) openRemoveConfirmDialog() bool {
+	if len(m.installed.Items()) == 0 {
+		return false
+	}
+	it, ok := m.installed.SelectedItem().(modInstalledItem)
+	if !ok {
+		return false
+	}
+	m.libraryToast = ""
+	m.modsDialog = modsDialogConfirmRemoveJar
+	m.modsDialogJar = it.jar.Name
+	return true
+}
+
+func (m *ModsModel) removeConfirmedJar(name string) {
+	idx := m.installed.Index()
+	if err := mods.RemoveInstalledJar(m.inst, name); err != nil {
+		m.installedErr = err.Error()
+		m.libraryToast = ""
+		return
+	}
+	m.installedErr = ""
+	if err := mods.DropCatalogEntriesForJar(m.inst, name); err != nil {
+		m.installedErr = fmt.Sprintf("Removed jar; catalog cleanup: %v", err)
+	}
+	m.installOK = ""
+	m.installErr = ""
+	m.libraryToast = fmt.Sprintf(`Removed "%s" from this instance.`, name)
+	m.loadInstalledJarList()
+	if n := len(m.installed.Items()); n > 0 {
+		if idx >= n {
+			idx = n - 1
+		}
+		m.installed.Select(idx)
+	}
+	m.rebuildBrowseBadges()
+}
+
+func (m *ModsModel) loadInstalledJarList() {
+	m.reloadCatalogAndJars()
+	m.installedErr = ""
+	jars, err := mods.ListInstalledJars(m.inst)
+	if err != nil {
+		m.installedErr = err.Error()
+		m.installed.SetItems(nil)
+		m.installed.Title = "Installed"
+		m.rebuildBrowseBadges()
+		return
+	}
+	m.cachedJars = jars
+	items := make([]list.Item, 0, len(jars))
+	for _, j := range jars {
+		j := j
+		items = append(items, modInstalledItem{jar: j})
+	}
+	m.installed.SetItems(items)
+	m.installed.Title = fmt.Sprintf("Installed (%d)", len(jars))
+	m.rebuildBrowseBadges()
+}
+
+func (m *ModsModel) refreshInstalled() {
+	m.clearModsDialog()
+	m.libraryToast = ""
+	m.loadInstalledJarList()
+}
+
+// SetSize updates layout dimensions.
+func (m *ModsModel) SetSize(w, h int) {
+	if w < 1 {
+		w = 1
+	}
+	if h < 1 {
+		h = 1
+	}
+	m.width, m.height = w, h
+	if m.blocked {
+		return
+	}
+	m.compactLayout = w < splitMinWidth
+	if m.compactLayout {
+		m.query.Width = min(60, max(24, w-10))
+		listW := max(20, w-6)
+		m.libraryListW = listW
+		m.resultsListW = listW
+		libH, browseH := modsCompactListHeights(h, w)
+		m.installed.SetSize(listW, libH)
+		m.results.SetSize(listW, browseH)
+		return
+	}
+	leftW := max(28, min(40, w*32/100))
+	rightInner := w - leftW - 5
+	if rightInner < 34 {
+		leftW = max(24, w*30/100)
+		rightInner = w - leftW - 5
+	}
+	m.query.Width = min(58, max(24, rightInner-4))
+	lw := max(22, leftW-4)
+	rw := max(28, rightInner-2)
+	m.libraryListW = lw
+	m.resultsListW = rw
+	listH := modsSplitListViewportHeight(h, w)
+	m.installed.SetSize(lw, listH)
+	m.results.SetSize(rw, listH)
+}
+
+func (m *ModsModel) cancelSearch() {
+	if m.searchCancel != nil {
+		m.searchCancel()
+		m.searchCancel = nil
+	}
+}
+
+func (m *ModsModel) cancelInstallDownload() {
+	if m.installCancel != nil {
+		m.installCancel()
+		m.installCancel = nil
+	}
+}
+
+// CancelPending stops in-flight Modrinth search and mod download. Call before discarding the model (e.g. leaving the screen).
+func (m *ModsModel) CancelPending() {
+	m.cancelSearch()
+	m.cancelInstallDownload()
+}
+
+// Init implements tea.Model.
+func (m *ModsModel) Init() tea.Cmd {
+	if m.blocked {
+		return nil
+	}
+	m.refreshInstalled()
+	m.cancelSearch()
+	m.cancelInstallDownload()
+	m.searchSeq++
+	seq := m.searchSeq
+	m.searching = true
+	m.searchErr = ""
+	m.searchNotice = ""
+	m.results.Title = "Modrinth — popular"
+	ctx, cancel := context.WithCancel(context.Background())
+	m.searchCancel = cancel
+	browse := func() tea.Msg {
+		res, err := m.svc.SearchFabricMods(ctx, m.inst, "", 0)
+		if err != nil && errors.Is(err, context.Canceled) {
+			return modSearchStaleMsg{}
+		}
+		return modSearchResultMsg{seq: seq, result: res, err: err}
+	}
+	return browse
+}
+
+func (m *ModsModel) footerHelpItems() []string {
+	if m.compactLayout {
+		return modsCompactFooterItems(m.height, m.width)
+	}
+	return modsHelpItemsPick(m.height, m.width)
+}
+
+func (m *ModsModel) cycleTab() {
+	m.clearModsDialog()
+	switch m.modsFocus {
+	case panelInstalled:
+		m.modsFocus = panelQuery
+		m.query.Focus()
+	case panelQuery:
+		m.query.Blur()
+		m.modsFocus = panelBrowse
+	case panelBrowse:
+		m.modsFocus = panelInstalled
+	}
+}
+
+func (m *ModsModel) panelBorderFocused(p modsPanel) lipgloss.Style {
+	s := lipgloss.NewStyle().Padding(0, 1).Border(lipgloss.RoundedBorder())
+	if m.modsFocus == p {
+		return s.BorderForeground(lipgloss.Color("#10B981"))
+	}
+	if p == panelInstalled {
+		return s.BorderForeground(lipgloss.Color("#57534E"))
+	}
+	return s.BorderForeground(lipgloss.Color("#27272A"))
+}
+
+func (m *ModsModel) rightColumnFocused() bool {
+	return m.modsFocus == panelBrowse || m.modsFocus == panelQuery
+}
+
+func (m *ModsModel) runSearchQuery() tea.Cmd {
+	q := strings.TrimSpace(m.query.Value())
+	m.searching = true
+	m.searchErr = ""
+	m.searchNotice = ""
+	seq := m.searchSeq
+	ctx, cancel := context.WithCancel(context.Background())
+	m.searchCancel = cancel
+	return func() tea.Msg {
+		res, err := m.svc.SearchFabricMods(ctx, m.inst, q, 0)
+		if err != nil && errors.Is(err, context.Canceled) {
+			return modSearchStaleMsg{}
+		}
+		return modSearchResultMsg{seq: seq, result: res, err: err}
+	}
+}
+
+func (m *ModsModel) installModCmd(projectID, title, slug string) tea.Cmd {
+	m.cancelInstallDownload()
+	m.searchNotice = ""
+	m.installing = true
+	m.installErr = ""
+	m.installOK = ""
+	inst := m.inst
+	svc := m.svc
+	ctx, cancel := context.WithCancel(context.Background())
+	m.installCancel = cancel
+	ch := make(chan ModInstallDoneMsg, 1)
+	go func() {
+		defer cancel()
+		path, err := svc.InstallFabricMod(ctx, inst, projectID)
+		ch <- ModInstallDoneMsg{
+			ProjectID: projectID,
+			Slug:      slug,
+			Title:     title,
+			Path:      path,
+			Err:       err,
+		}
+	}()
+	return func() tea.Msg {
+		return <-ch
+	}
+}

--- a/internal/ui/mods_types.go
+++ b/internal/ui/mods_types.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/dustin/go-humanize"
-	"github.com/quasar/mctui/internal/api"
-	"github.com/quasar/mctui/internal/mods"
+	"github.com/mctui/mctui/internal/api"
+	"github.com/mctui/mctui/internal/mods"
 )
 
 const splitMinWidth = 78

--- a/internal/ui/mods_types.go
+++ b/internal/ui/mods_types.go
@@ -1,0 +1,92 @@
+package ui
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/dustin/go-humanize"
+	"github.com/quasar/mctui/internal/api"
+	"github.com/quasar/mctui/internal/mods"
+)
+
+const splitMinWidth = 78
+
+type modsPanel int
+
+const (
+	panelInstalled modsPanel = iota
+	panelQuery
+	panelBrowse
+)
+
+type modsDialogKind int
+
+const (
+	modsDialogNone modsDialogKind = iota
+	modsDialogConfirmRemoveJar
+)
+
+type modSearchDueMsg struct{ seq int }
+type modSearchStaleMsg struct{}
+type modSearchResultMsg struct {
+	seq    int
+	result *api.SearchResult
+	err    error
+}
+
+const (
+	modRowInstalled  = "✓ Installed"
+	modRowInstalling = "Installing…"
+)
+
+type modListItem struct {
+	hit     api.SearchHit
+	rowNote string // modRow* or ""
+}
+
+func (i modListItem) Title() string {
+	t := lipgloss.NewStyle().Foreground(lipgloss.Color("#F4F4F5")).Render(i.hit.Title)
+	switch i.rowNote {
+	case modRowInstalled:
+		dot := lipgloss.NewStyle().Foreground(lipgloss.Color("#34D399")).Render("● ")
+		return dot + t
+	case modRowInstalling:
+		dot := lipgloss.NewStyle().Foreground(lipgloss.Color("#FBBF24")).Render("◆ ")
+		return dot + t
+	default:
+		return i.hit.Title
+	}
+}
+
+func (i modListItem) Description() string {
+	meta := fmt.Sprintf("%s • %s", api.FormatDownloads(i.hit.Downloads), i.hit.Slug)
+	metaStyled := lipgloss.NewStyle().Foreground(lipgloss.Color("#71717A")).Render(meta)
+	switch i.rowNote {
+	case modRowInstalled:
+		pill := lipgloss.NewStyle().
+			Background(lipgloss.Color("#14532D")).
+			Foreground(lipgloss.Color("#A7F3D0")).
+			Padding(0, 1).
+			Render("installed")
+		return lipgloss.JoinHorizontal(lipgloss.Left, pill, " ", metaStyled)
+	case modRowInstalling:
+		pill := lipgloss.NewStyle().
+			Background(lipgloss.Color("#422006")).
+			Foreground(lipgloss.Color("#FCD34D")).
+			Padding(0, 1).
+			Render("installing")
+		return lipgloss.JoinHorizontal(lipgloss.Left, pill, " ", metaStyled)
+	default:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("#A1A1AA")).Render(meta)
+	}
+}
+
+func (i modListItem) FilterValue() string { return i.hit.Title + " " + i.hit.Slug }
+
+type modInstalledItem struct {
+	jar mods.InstalledJar
+}
+
+func (i modInstalledItem) Title() string       { return i.jar.Name }
+func (i modInstalledItem) Description() string { return humanize.Bytes(uint64(i.jar.Size)) }
+func (i modInstalledItem) FilterValue() string { return i.jar.Name }

--- a/internal/ui/mods_update.go
+++ b/internal/ui/mods_update.go
@@ -1,0 +1,349 @@
+package ui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/quasar/mctui/internal/mods"
+)
+
+// Update implements tea.Model.
+func (m *ModsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.blocked {
+		switch msg := msg.(type) {
+		case tea.KeyMsg:
+			if msg.String() == "esc" || msg.String() == "q" {
+				m.CancelPending()
+				return m, func() tea.Msg { return NavigateToHome{} }
+			}
+		}
+		return m, nil
+	}
+
+	switch msg := msg.(type) {
+	case tea.MouseMsg:
+		if m.installing {
+			return m, nil
+		}
+		switch msg.Type {
+		case tea.MouseWheelUp:
+			switch m.modsFocus {
+			case panelInstalled:
+				m.clearModsDialog()
+				m.libraryToast = ""
+				if len(m.installed.Items()) > 0 {
+					m.installed.CursorUp()
+				}
+			case panelBrowse:
+				if len(m.results.Items()) > 0 {
+					m.results.CursorUp()
+				}
+			case panelQuery:
+				if len(m.results.Items()) > 0 {
+					m.results.CursorUp()
+				}
+			}
+		case tea.MouseWheelDown:
+			switch m.modsFocus {
+			case panelInstalled:
+				m.clearModsDialog()
+				m.libraryToast = ""
+				if len(m.installed.Items()) > 0 {
+					m.installed.CursorDown()
+				}
+			case panelBrowse:
+				if len(m.results.Items()) > 0 {
+					m.results.CursorDown()
+				}
+			case panelQuery:
+				if len(m.results.Items()) > 0 {
+					m.results.CursorDown()
+				}
+			}
+		default:
+			return m, nil
+		}
+		return m, nil
+
+	case tea.KeyMsg:
+		if m.installing && msg.String() != "esc" {
+			return m, nil
+		}
+
+		if m.modsDialog == modsDialogConfirmRemoveJar {
+			switch msg.String() {
+			case "y", "Y", "enter":
+				jar := m.modsDialogJar
+				m.clearModsDialog()
+				m.removeConfirmedJar(jar)
+				return m, nil
+			case "n", "N", "esc", "backspace":
+				m.clearModsDialog()
+				return m, nil
+			default:
+				return m, nil
+			}
+		}
+
+		switch msg.String() {
+		case "esc":
+			m.CancelPending()
+			if m.installing {
+				m.installing = false
+				m.installingProjectID = ""
+				m.rebuildBrowseBadges()
+			}
+			return m, func() tea.Msg { return NavigateToHome{} }
+		case "tab", "shift+tab":
+			m.libraryToast = ""
+			m.cycleTab()
+			if m.modsFocus == panelQuery {
+				return m, textinput.Blink
+			}
+			return m, nil
+		case "r", "R":
+			// Let query field receive "r" (e.g. sodium, fabric-apiR…).
+			if m.modsFocus != panelQuery {
+				m.refreshInstalled()
+				return m, nil
+			}
+		case "d":
+			if m.modsFocus == panelInstalled && m.openRemoveConfirmDialog() {
+				return m, nil
+			}
+		case "backspace":
+			if m.modsFocus == panelInstalled && m.openRemoveConfirmDialog() {
+				return m, nil
+			}
+		case "/":
+			// Typing "/" in the search box should not jump/refocus the field.
+			if m.modsFocus != panelQuery {
+				m.libraryToast = ""
+				m.modsFocus = panelQuery
+				m.query.Focus()
+				return m, textinput.Blink
+			}
+		}
+
+		switch msg.String() {
+		case "left":
+			if m.modsFocus == panelBrowse || m.modsFocus == panelQuery {
+				m.libraryToast = ""
+				m.modsFocus = panelInstalled
+				m.query.Blur()
+				return m, nil
+			}
+			if m.modsFocus == panelInstalled {
+				m.clearModsDialog()
+				m.libraryToast = ""
+			}
+		case "right":
+			if m.modsFocus == panelInstalled {
+				m.clearModsDialog()
+				m.libraryToast = ""
+				m.modsFocus = panelBrowse
+				return m, nil
+			}
+		}
+
+		if m.modsFocus == panelQuery && msg.String() == "down" {
+			if len(m.results.Items()) > 0 {
+				m.modsFocus = panelBrowse
+				m.query.Blur()
+				return m, nil
+			}
+		}
+		if m.modsFocus == panelQuery && msg.String() == "up" {
+			m.modsFocus = panelInstalled
+			m.query.Blur()
+			if len(m.installed.Items()) > 0 {
+				m.installed.Select(len(m.installed.Items()) - 1)
+			}
+			return m, nil
+		}
+
+		if m.modsFocus == panelQuery && msg.String() == "enter" {
+			m.cancelSearch()
+			m.searchSeq++
+			if strings.TrimSpace(m.query.Value()) == "" {
+				m.results.Title = "Modrinth — popular"
+			} else {
+				m.results.Title = "Modrinth — search"
+			}
+			m.searchNotice = ""
+			return m, m.runSearchQuery()
+		}
+
+		if m.modsFocus == panelQuery {
+			old := m.query.Value()
+			var cmd tea.Cmd
+			m.query, cmd = m.query.Update(msg)
+			if m.query.Value() != old {
+				m.cancelSearch()
+				m.searchSeq++
+				seq := m.searchSeq
+				if strings.TrimSpace(m.query.Value()) == "" {
+					m.results.Title = "Modrinth — popular"
+				} else {
+					m.results.Title = "Modrinth — search"
+				}
+				m.searchNotice = ""
+				return m, tea.Batch(cmd, tea.Tick(350*time.Millisecond, func(time.Time) tea.Msg {
+					return modSearchDueMsg{seq: seq}
+				}))
+			}
+			return m, cmd
+		}
+
+		if m.modsFocus == panelBrowse && (msg.String() == "up" || msg.String() == "k") && m.results.Index() == 0 {
+			m.modsFocus = panelQuery
+			m.query.Focus()
+			return m, textinput.Blink
+		}
+
+		if m.modsFocus == panelInstalled && msg.String() == "up" && m.installed.Index() == 0 {
+			m.clearModsDialog()
+			m.libraryToast = ""
+			m.modsFocus = panelQuery
+			m.query.Focus()
+			return m, textinput.Blink
+		}
+		if m.modsFocus == panelInstalled && msg.String() == "down" {
+			n := len(m.installed.Items())
+			if n > 0 && m.installed.Index() >= n-1 {
+				m.clearModsDialog()
+				m.libraryToast = ""
+				m.modsFocus = panelBrowse
+				return m, nil
+			}
+		}
+
+		if m.modsFocus == panelInstalled && key.Matches(msg, key.NewBinding(key.WithKeys("enter"))) {
+			if m.openRemoveConfirmDialog() {
+				return m, nil
+			}
+		}
+
+		if m.modsFocus == panelBrowse && key.Matches(msg, key.NewBinding(key.WithKeys("enter"))) {
+			if it, ok := m.results.SelectedItem().(modListItem); ok {
+				if m.installing {
+					m.installOK = ""
+					m.installErr = ""
+					m.searchNotice = "A download is already in progress."
+					return m, nil
+				}
+				if it.rowNote == modRowInstalled ||
+					mods.IsModrinthProjectInstalled(m.catalog, m.cachedJars, it.hit.ProjectID, it.hit.Slug) {
+					m.installOK = ""
+					m.installErr = ""
+					m.searchNotice = "Already installed — skipped."
+					return m, nil
+				}
+				m.installingProjectID = it.hit.ProjectID
+				m.rebuildBrowseBadges()
+				return m, m.installModCmd(it.hit.ProjectID, it.hit.Title, it.hit.Slug)
+			}
+			return m, nil
+		}
+
+		var cmd tea.Cmd
+		switch m.modsFocus {
+		case panelInstalled:
+			m.installed, cmd = m.installed.Update(msg)
+			m.syncModsDialogSelection()
+		case panelBrowse:
+			m.results, cmd = m.results.Update(msg)
+		}
+		return m, cmd
+
+	case modSearchDueMsg:
+		if msg.seq != m.searchSeq {
+			return m, nil
+		}
+		return m, m.runSearchQuery()
+
+	case modSearchStaleMsg:
+		return m, nil
+
+	case modSearchResultMsg:
+		if msg.seq != m.searchSeq {
+			return m, nil
+		}
+		m.searching = false
+		m.searchCancel = nil
+		if msg.err != nil {
+			if errors.Is(msg.err, context.Canceled) {
+				return m, nil
+			}
+			m.searchErr = msg.err.Error()
+			m.searchNotice = ""
+			m.lastTotalHits = 0
+			m.results.SetItems(nil)
+			return m, nil
+		}
+		m.searchErr = ""
+		if msg.result == nil {
+			m.searchNotice = ""
+			m.lastTotalHits = 0
+			m.results.SetItems(nil)
+			return m, nil
+		}
+		m.lastTotalHits = msg.result.TotalHits
+		m.results.SetItems(m.hitsToItems(msg.result.Hits))
+		if len(msg.result.Hits) == 0 {
+			m.searchNotice = "No matches. Clear the search for popular picks on this version."
+		} else {
+			m.searchNotice = ""
+		}
+		if strings.TrimSpace(m.query.Value()) == "" {
+			m.results.Title = "Modrinth — popular"
+		} else {
+			m.results.Title = "Modrinth — search"
+		}
+		return m, nil
+
+	case ModInstallDoneMsg:
+		m.installing = false
+		m.installingProjectID = ""
+		m.cancelInstallDownload()
+		m.installErr = ""
+		m.installOK = ""
+		if msg.Err != nil {
+			if errors.Is(msg.Err, context.Canceled) {
+				m.rebuildBrowseBadges()
+				return m, nil
+			}
+			m.installErr = msg.Err.Error()
+			m.rebuildBrowseBadges()
+			return m, nil
+		}
+		if err := mods.RecordModrinthInstall(m.inst, msg.ProjectID, msg.Slug, filepath.Base(msg.Path)); err != nil {
+			m.installErr = fmt.Sprintf("Saved jar but catalog: %v", err)
+		}
+		m.reloadCatalogAndJars()
+		m.refreshInstalled()
+		m.rebuildBrowseBadges()
+		short := filepath.Base(msg.Path)
+		m.installOK = fmt.Sprintf("Added %s (%s) ✓  — restart Minecraft to load", msg.Title, short)
+		return m, nil
+	}
+
+	var cmd tea.Cmd
+	switch m.modsFocus {
+	case panelQuery:
+		m.query, cmd = m.query.Update(msg)
+	case panelInstalled:
+		m.installed, cmd = m.installed.Update(msg)
+		m.syncModsDialogSelection()
+	case panelBrowse:
+		m.results, cmd = m.results.Update(msg)
+	}
+	return m, cmd
+}

--- a/internal/ui/mods_update.go
+++ b/internal/ui/mods_update.go
@@ -11,7 +11,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/quasar/mctui/internal/mods"
+	"github.com/mctui/mctui/internal/mods"
 )
 
 // Update implements tea.Model.

--- a/internal/ui/mods_view.go
+++ b/internal/ui/mods_view.go
@@ -1,0 +1,217 @@
+package ui
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/quasar/mctui/internal/mods"
+)
+
+func (m *ModsModel) libraryBannerBlock(nLocal int) string {
+	if m.installedErr != "" {
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("#EF4444")).Render(m.installedErr)
+	}
+	if m.modsDialog == modsDialogConfirmRemoveJar {
+		box := lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("#78716C")).
+			Padding(0, 1).
+			MarginBottom(0)
+		q := lipgloss.NewStyle().Foreground(lipgloss.Color("#FAFAFA")).
+			Render(fmt.Sprintf("Remove %q from this instance?", m.modsDialogJar))
+		actions := lipgloss.NewStyle().Foreground(lipgloss.Color("#A8A29E")).
+			Render("[y] or Enter confirm  ·  [n] or Backspace cancel")
+		return box.Render(lipgloss.JoinVertical(lipgloss.Left, q, actions))
+	}
+	if m.libraryToast != "" {
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("#6EE7B7")).Render(m.libraryToast)
+	}
+	if len(m.installed.Items()) == 0 {
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("#71717A")).Render("Empty — browse →")
+	}
+	return lipgloss.NewStyle().Foreground(lipgloss.Color("#57534E")).
+		Render(fmt.Sprintf("%d jar(s) · %s", nLocal, filepath.Base(mods.ModsDir(m.inst))))
+}
+
+func (m *ModsModel) buildModrinthChrome(status string, statusVisible bool, meta, discoverHint string) string {
+	title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#C4B5FD")).Render("Discover")
+	sub := lipgloss.NewStyle().Foreground(lipgloss.Color("#52525B")).Render("Modrinth · Fabric mods for this version")
+	header := lipgloss.JoinHorizontal(lipgloss.Left, title, "  ", sub)
+
+	qLabel := lipgloss.NewStyle().Foreground(lipgloss.Color("#57534E")).Render("Query")
+	if m.modsFocus == panelQuery {
+		qLabel = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#10B981")).Render("Query")
+	}
+	searchBox := m.query.View()
+	if m.modsFocus != panelQuery {
+		searchBox = lipgloss.NewStyle().Foreground(lipgloss.Color("#71717A")).Render(searchBox)
+	}
+	queryRow := lipgloss.JoinVertical(lipgloss.Left, qLabel, searchBox)
+
+	statusBlock := ""
+	if statusVisible && strings.TrimSpace(status) != "" {
+		bar := lipgloss.NewStyle().Foreground(lipgloss.Color("#7C3AED")).Render("┃ ")
+		statusBlock = lipgloss.JoinHorizontal(lipgloss.Top, bar, status)
+	}
+
+	aux := ""
+	if strings.TrimSpace(meta) != "" && strings.TrimSpace(discoverHint) != "" {
+		aux = lipgloss.JoinHorizontal(lipgloss.Left,
+			lipgloss.NewStyle().Foreground(lipgloss.Color("#52525B")).Render(meta),
+			lipgloss.NewStyle().Foreground(lipgloss.Color("#3F3F46")).Render("  ·  "),
+			discoverHint,
+		)
+	} else if strings.TrimSpace(meta) != "" {
+		aux = meta
+	} else {
+		aux = discoverHint
+	}
+
+	return lipgloss.JoinVertical(lipgloss.Left,
+		header,
+		"",
+		queryRow,
+		statusBlock,
+		aux,
+	)
+}
+
+// View implements tea.Model.
+func (m *ModsModel) View() string {
+	if m.blocked {
+		brand := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7C3AED")).Render("Mods")
+		divider := lipgloss.NewStyle().Foreground(lipgloss.Color("#3F3F46")).Render(strings.Repeat("─", min(42, max(24, m.width-8))))
+		body := lipgloss.JoinVertical(
+			lipgloss.Center,
+			brand,
+			lipgloss.NewStyle().Foreground(lipgloss.Color("#A1A1AA")).Render("Fabric instances only"),
+			"",
+			divider,
+			"",
+			lipgloss.NewStyle().Foreground(lipgloss.Color("#FAFAFA")).
+				Render("Select a Fabric instance on home, then press [m]."),
+			"",
+			lipgloss.NewStyle().Foreground(lipgloss.Color("#626262")).Render("[esc]  Back"),
+		)
+		return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, body)
+	}
+
+	nLocal := len(m.installed.Items())
+
+	contentInnerW := max(24, m.width-8)
+	brand := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#E9D5FF")).Render("Mods")
+	ctxLine := lipgloss.NewStyle().Foreground(lipgloss.Color("#A1A1AA")).Render(
+		fmt.Sprintf("%s · Minecraft %s · Fabric · %d installed", m.inst.Name, m.inst.Version, nLocal))
+	shellRule := lipgloss.NewStyle().Foreground(lipgloss.Color("#27272A")).Render(strings.Repeat("─", contentInnerW))
+	header := lipgloss.NewStyle().MarginBottom(1).Render(lipgloss.JoinVertical(
+		lipgloss.Left, brand, ctxLine, shellRule))
+
+	modrinthStatus := ""
+	modrinthStatusVisible := false
+	switch {
+	case m.installing:
+		modrinthStatus = lipgloss.NewStyle().Foreground(lipgloss.Color("#A78BFA")).Render("Downloading selected mod…")
+		modrinthStatusVisible = true
+	case m.installErr != "":
+		modrinthStatus = lipgloss.NewStyle().Foreground(lipgloss.Color("#EF4444")).Render(m.installErr)
+		modrinthStatusVisible = true
+	case m.installOK != "":
+		modrinthStatus = lipgloss.NewStyle().Foreground(lipgloss.Color("#34D399")).Render(m.installOK)
+		modrinthStatusVisible = true
+	case m.searching:
+		modrinthStatusVisible = true
+		if strings.TrimSpace(m.query.Value()) == "" {
+			modrinthStatus = lipgloss.NewStyle().Foreground(lipgloss.Color("#A1A1AA")).Render("Loading Modrinth…")
+		} else {
+			modrinthStatus = lipgloss.NewStyle().Foreground(lipgloss.Color("#A1A1AA")).Render("Searching…")
+		}
+	case m.searchErr != "":
+		modrinthStatus = lipgloss.NewStyle().Foreground(lipgloss.Color("#EF4444")).Render(m.searchErr)
+		modrinthStatusVisible = true
+	case m.searchNotice != "":
+		modrinthStatus = lipgloss.NewStyle().Foreground(lipgloss.Color("#FBBF24")).Render(m.searchNotice)
+		modrinthStatusVisible = true
+	}
+
+	meta := ""
+	if !m.searching && m.searchErr == "" && m.lastTotalHits > 0 && len(m.results.Items()) > 0 {
+		meta = lipgloss.NewStyle().Foreground(lipgloss.Color("#52525B")).
+			Render(fmt.Sprintf("Showing %d of ~%s projects", len(m.results.Items()), formatModHitCount(m.lastTotalHits)))
+	}
+
+	discoverHint := ""
+	if len(m.results.Items()) > 0 && !m.searching {
+		discoverHint = lipgloss.NewStyle().Foreground(lipgloss.Color("#52525B")).Italic(true).
+			Render("● = already installed   ◆ = installing")
+	}
+
+	libBanner := m.libraryBannerBlock(nLocal)
+
+	libW := m.libraryListW
+	if libW < 4 {
+		libW = 22
+	}
+	resW := m.resultsListW
+	if resW < 4 {
+		resW = 28
+	}
+	libHdr := modPanelSectionHeader(m.installed.Title, "#34D399", libW)
+	browseHdr := modPanelSectionHeader(m.results.Title, "#A78BFA", resW)
+
+	libraryInner := lipgloss.JoinVertical(lipgloss.Left,
+		libBanner,
+		libHdr,
+		m.installed.View(),
+	)
+	rightTop := m.buildModrinthChrome(modrinthStatus, modrinthStatusVisible, meta, discoverHint)
+	rightInner := lipgloss.JoinVertical(lipgloss.Left,
+		rightTop,
+		browseHdr,
+		m.results.View(),
+	)
+
+	if !m.compactLayout {
+		hl := lipgloss.Height(libraryInner)
+		hr := lipgloss.Height(rightInner)
+		mx := max(hl, hr)
+		if mx > 0 {
+			libraryInner = lipgloss.PlaceVertical(mx, lipgloss.Top, libraryInner)
+			rightInner = lipgloss.PlaceVertical(mx, lipgloss.Top, rightInner)
+		}
+	}
+
+	libraryView := m.panelBorderFocused(panelInstalled).Render(libraryInner)
+
+	rightPane := lipgloss.NewStyle().Padding(0, 1).Border(lipgloss.RoundedBorder())
+	if m.rightColumnFocused() {
+		rightPane = rightPane.BorderForeground(lipgloss.Color("#10B981"))
+	} else {
+		rightPane = rightPane.BorderForeground(lipgloss.Color("#27272A"))
+	}
+	browseBox := rightPane.Render(rightInner)
+
+	layout := ""
+	if m.compactLayout {
+		layout = lipgloss.JoinVertical(lipgloss.Left,
+			header,
+			"",
+			libraryView,
+			"",
+			browseBox,
+		)
+	} else {
+		row := lipgloss.JoinHorizontal(lipgloss.Top, libraryView, strings.Repeat(" ", 2), browseBox)
+		layout = lipgloss.JoinVertical(lipgloss.Left, header, "", row)
+	}
+
+	helpItems := m.footerHelpItems()
+	helpRule := lipgloss.NewStyle().Foreground(lipgloss.Color("#3F3F46")).Render(strings.Repeat("─", min(contentInnerW, 56)))
+	help := lipgloss.JoinVertical(lipgloss.Left,
+		helpRule,
+		lipgloss.NewStyle().Foreground(lipgloss.Color("#626262")).MarginTop(1).Render(buildHelpText(helpItems, m.width-6)))
+
+	return lipgloss.Place(m.width, m.height, lipgloss.Left, lipgloss.Top,
+		lipgloss.NewStyle().Padding(1, 2).Render(lipgloss.JoinVertical(lipgloss.Left, layout, "", help)))
+}

--- a/internal/ui/mods_view.go
+++ b/internal/ui/mods_view.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/quasar/mctui/internal/mods"
+	"github.com/mctui/mctui/internal/mods"
 )
 
 func (m *ModsModel) libraryBannerBlock(nLocal int) string {

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -16,11 +16,20 @@ var (
 	ColorSubtle    = lipgloss.Color("#A1A1AA") // Zinc
 )
 
+// App shell: consistent inset from the terminal edge for every full-screen view.
+// Apply in the root View after sizing children to (terminal − 2*pad).
+const (
+	AppShellPadY = 1
+	AppShellPadX = 2
+)
+
+// AppShellStyle wraps rendered views with the standard horizontal/vertical padding.
+var AppShellStyle = lipgloss.NewStyle().Padding(AppShellPadY, AppShellPadX)
+
 // Shared styles
 var (
-	// Container styles
-	ContainerStyle = lipgloss.NewStyle().
-			Padding(1, 2)
+	// ContainerStyle matches [AppShellStyle] (legacy alias).
+	ContainerStyle = AppShellStyle
 
 	// Title styles
 	TitleStyle = lipgloss.NewStyle().

--- a/internal/ui/wizard.go
+++ b/internal/ui/wizard.go
@@ -10,7 +10,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/quasar/mctui/internal/core"
+	"github.com/mctui/mctui/internal/core"
 )
 
 // WizardStep represents the current wizard step

--- a/internal/ui/wizard.go
+++ b/internal/ui/wizard.go
@@ -22,6 +22,15 @@ const (
 	StepEnterName
 )
 
+// nameFormFocus is which control is active on the name step.
+type nameFormFocus int
+
+const (
+	focusWizardName            nameFormFocus = iota
+	focusWizardStarterCheckbox               // Fabric only (skipped in focus order when not Fabric)
+	focusWizardSubmit
+)
+
 // loaderChoice is one row in the mod loader step (extensible for future loaders).
 type loaderChoice struct {
 	Label      string
@@ -51,6 +60,10 @@ type WizardModel struct {
 	// Name input
 	nameInput textinput.Model
 	nameErr   string
+
+	// Fabric only: opt-in starter mods (Fabric API, Mod Menu, Sodium, Lithium) after create.
+	installStarterMods bool
+	nameFormFocus      nameFormFocus
 
 	existingNames map[string]struct{}
 
@@ -103,6 +116,8 @@ func NewWizardModel(instances []*core.Instance) *WizardModel {
 	ti.Placeholder = "My Instance"
 	ti.CharLimit = 64
 	ti.Width = 40
+	ti.PromptStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#71717A"))
+	ti.TextStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#FAFAFA"))
 
 	existingNames := make(map[string]struct{})
 	for _, inst := range instances {
@@ -112,15 +127,17 @@ func NewWizardModel(instances []*core.Instance) *WizardModel {
 	return &WizardModel{
 		step:        StepSelectVersion,
 		versionList: vl,
+		// loaderIndex 0 = Fabric (first row; Vanilla below)
 		loaderChoices: []loaderChoice{
-			{Label: "Vanilla", ID: "vanilla"},
 			{Label: "Fabric", ID: "fabric"},
+			{Label: "Vanilla", ID: "vanilla"},
 			{Label: "Forge (coming soon)", ID: "", ComingSoon: true},
 			{Label: "Quilt (coming soon)", ID: "", ComingSoon: true},
 		},
-		nameInput:     ti,
-		loading:       true,
-		existingNames: existingNames,
+		nameInput:          ti,
+		installStarterMods: true,
+		loading:            true,
+		existingNames:      existingNames,
 	}
 }
 
@@ -169,9 +186,20 @@ func (m *WizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
+		// Space: toggle Fabric starter row (KeySpace and rune " " differ by platform/driver).
+		if m.step == StepEnterName && m.selectedLoader == "fabric" &&
+			m.nameFormFocus == focusWizardStarterCheckbox &&
+			(msg.Type == tea.KeySpace || msg.String() == " " || msg.String() == "space") {
+			m.installStarterMods = !m.installStarterMods
+			return m, nil
+		}
 		switch msg.String() {
 		case "esc":
 			if m.step > StepSelectVersion {
+				if m.step == StepEnterName {
+					m.nameErr = ""
+					m.nameStepSetFocus(focusWizardName)
+				}
 				m.step--
 				return m, nil
 			}
@@ -181,21 +209,51 @@ func (m *WizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.step == StepSelectVersion {
 				m.showSnaps = !m.showSnaps
 				m.updateVersionList("")
+				return m, nil
+			}
+			if m.step == StepEnterName {
+				m.nameStepCycleFocus(1)
+				return m, textinput.Blink
 			}
 			return m, nil
 
+		case "shift+tab":
+			if m.step == StepEnterName {
+				m.nameStepCycleFocus(-1)
+				return m, textinput.Blink
+			}
+
 		case "enter":
+			if m.step == StepEnterName {
+				return m.handleNameStepEnter()
+			}
 			return m.handleEnter()
 
-		case "up", "k":
-			if m.step == StepSelectLoader && m.loaderIndex > 0 {
+		case "up":
+			if m.step == StepSelectLoader {
 				m.loaderHint = ""
-				m.loaderIndex--
+				m.moveLoaderSelection(-1)
+			} else if m.step == StepEnterName {
+				m.nameStepCycleFocus(-1)
+				return m, textinput.Blink
 			}
-		case "down", "j":
-			if m.step == StepSelectLoader && m.loaderIndex < len(m.loaderChoices)-1 {
+		case "down":
+			if m.step == StepSelectLoader {
 				m.loaderHint = ""
-				m.loaderIndex++
+				m.moveLoaderSelection(1)
+			} else if m.step == StepEnterName {
+				m.nameStepCycleFocus(1)
+				return m, textinput.Blink
+			}
+		case "k":
+			if m.step == StepSelectLoader {
+				m.loaderHint = ""
+				m.moveLoaderSelection(-1)
+			}
+		case "j":
+			if m.step == StepSelectLoader {
+				m.loaderHint = ""
+				m.moveLoaderSelection(1)
 			}
 		}
 	}
@@ -210,7 +268,9 @@ func (m *WizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.versionList, cmd = m.versionList.Update(msg)
 	case StepEnterName:
-		m.nameInput, cmd = m.nameInput.Update(msg)
+		if m.nameFormFocus == focusWizardName {
+			m.nameInput, cmd = m.nameInput.Update(msg)
+		}
 	}
 
 	return m, cmd
@@ -232,32 +292,124 @@ func (m *WizardModel) handleEnter() (*WizardModel, tea.Cmd) {
 		m.selectedLoader = ch.ID
 		m.selectedLoaderLabel = ch.Label
 		m.loaderHint = ""
+		m.installStarterMods = ch.ID == "fabric"
+		m.nameStepSetFocus(focusWizardName)
 		m.step = StepEnterName
 		m.nameInput.SetValue(fmt.Sprintf("%s %s", m.selectedVersion, ch.Label))
 		m.nameInput.Focus()
-	case StepEnterName:
-		name := strings.TrimSpace(m.nameInput.Value())
-		if name == "" {
-			name = "New Instance"
-		}
-
-		if err := validateInstanceName(name, m.existingNames); err != nil {
-			m.nameErr = err.Error()
-			return m, nil
-		}
-		m.nameErr = ""
-
-		inst := &core.Instance{
-			ID:         name,
-			Name:       name,
-			Version:    m.selectedVersion,
-			Loader:     m.selectedLoader,
-			LastPlayed: time.Time{},
-		}
-
-		return m, func() tea.Msg { return InstanceCreated{Instance: inst} }
 	}
 	return m, nil
+}
+
+func (m *WizardModel) nameStepFocusOrder() []nameFormFocus {
+	if m.selectedLoader == "fabric" {
+		return []nameFormFocus{
+			focusWizardName,
+			focusWizardStarterCheckbox,
+			focusWizardSubmit,
+		}
+	}
+	return []nameFormFocus{focusWizardName, focusWizardSubmit}
+}
+
+func (m *WizardModel) nameStepSetFocus(f nameFormFocus) {
+	m.nameFormFocus = f
+	if f == focusWizardName {
+		m.nameInput.Focus()
+	} else {
+		m.nameInput.Blur()
+	}
+}
+
+func (m *WizardModel) nameStepCycleFocus(delta int) {
+	order := m.nameStepFocusOrder()
+	if len(order) == 0 {
+		return
+	}
+	idx := 0
+	found := false
+	for i, focus := range order {
+		if focus == m.nameFormFocus {
+			idx = i
+			found = true
+			break
+		}
+	}
+	if !found {
+		m.nameStepSetFocus(order[0])
+		return
+	}
+	n := len(order)
+	next := (idx + delta + n) % n
+	m.nameStepSetFocus(order[next])
+}
+
+func (m *WizardModel) handleNameStepEnter() (*WizardModel, tea.Cmd) {
+	switch m.nameFormFocus {
+	case focusWizardStarterCheckbox:
+		m.installStarterMods = !m.installStarterMods
+		return m, nil
+	case focusWizardName, focusWizardSubmit:
+		return m.submitNameStep()
+	default:
+		return m, nil
+	}
+}
+
+func (m *WizardModel) submitNameStep() (*WizardModel, tea.Cmd) {
+	name := strings.TrimSpace(m.nameInput.Value())
+	if name == "" {
+		name = "New Instance"
+	}
+	if err := validateInstanceName(name, m.existingNames); err != nil {
+		m.nameErr = err.Error()
+		m.nameStepSetFocus(focusWizardName)
+		return m, textinput.Blink
+	}
+	m.nameErr = ""
+
+	inst := &core.Instance{
+		ID:                       name,
+		Name:                     name,
+		Version:                  m.selectedVersion,
+		Loader:                   m.selectedLoader,
+		LastPlayed:               time.Time{},
+		InstallStarterFabricMods: m.installStarterMods && m.selectedLoader == "fabric",
+	}
+
+	return m, func() tea.Msg {
+		return InstanceCreated{
+			Instance:                 inst,
+			InstallStarterFabricMods: inst.InstallStarterFabricMods,
+		}
+	}
+}
+
+// moveLoaderSelection cycles only among loaders that are not ComingSoon (delta +1 = down, -1 = up).
+func (m *WizardModel) moveLoaderSelection(delta int) {
+	var selectable []int
+	for i, ch := range m.loaderChoices {
+		if !ch.ComingSoon {
+			selectable = append(selectable, i)
+		}
+	}
+	if len(selectable) == 0 {
+		return
+	}
+	cur := -1
+	for i, ix := range selectable {
+		if ix == m.loaderIndex {
+			cur = i
+			break
+		}
+	}
+	if cur < 0 {
+		m.loaderIndex = selectable[0]
+		return
+	}
+	n := len(selectable)
+	next := (cur + delta + n) % n
+	m.loaderIndex = selectable[next]
 }
 
 // View implements tea.Model
@@ -378,38 +530,130 @@ func (m *WizardModel) viewNameStep() string {
 	title := lipgloss.NewStyle().
 		Bold(true).
 		Foreground(lipgloss.Color("#FAFAFA")).
-		Render("Name Your Instance")
+		MarginBottom(0).
+		Render("Name your instance")
 
 	summary := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#A1A1AA")).
-		Render(fmt.Sprintf("Minecraft %s • %s", m.selectedVersion, m.selectedLoaderLabel))
+		MarginBottom(0).
+		Render(fmt.Sprintf("Minecraft %s · %s", m.selectedVersion, m.selectedLoaderLabel))
+
+	nameFocused := m.nameFormFocus == focusWizardName
+	nameBorder := lipgloss.Color("#3F3F46")
+	if nameFocused {
+		nameBorder = lipgloss.Color("#10B981")
+	}
+	fieldLabel := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#71717A")).
+		MarginBottom(0).
+		Render("Instance name")
 
 	inputStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("#10B981")).
+		BorderForeground(nameBorder).
 		Padding(0, 1)
 
 	errText := ""
 	if m.nameErr != "" {
 		errText = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#EF4444")).
+			MarginTop(1).
 			Render(m.nameErr)
 	}
 
+	nameBlock := lipgloss.JoinVertical(
+		lipgloss.Left,
+		fieldLabel,
+		inputStyle.Render(m.nameInput.View()),
+		errText,
+	)
+
+	starterBlock := ""
+	if m.selectedLoader == "fabric" {
+		cbFocused := m.nameFormFocus == focusWizardStarterCheckbox
+		mark := wizardCheckboxGlyph(m.installStarterMods, cbFocused)
+		titleLine := lipgloss.NewStyle().Foreground(lipgloss.Color("#E4E4E7")).Render("Install recommended Fabric mods")
+		sub := lipgloss.NewStyle().Foreground(lipgloss.Color("#71717A")).Render("Fabric API · Mod Menu · Sodium · Lithium")
+		labelCol := lipgloss.JoinVertical(lipgloss.Left, titleLine, sub)
+		row := lipgloss.JoinHorizontal(lipgloss.Top, mark, "  ", labelCol)
+		starterInner := lipgloss.JoinVertical(lipgloss.Left, row)
+		// Align □ with the text field prompt: border (1) + inner padding (1) = 2 cells.
+		rowStyle := lipgloss.NewStyle().PaddingLeft(2)
+		if cbFocused {
+			rowStyle = lipgloss.NewStyle().
+				Border(lipgloss.NormalBorder(), false, false, false, true).
+				BorderForeground(lipgloss.Color("#10B981")).
+				Background(lipgloss.Color("#27272A")).
+				PaddingLeft(1).
+				PaddingRight(1)
+		}
+		starterBlock = rowStyle.Render(starterInner)
+	}
+
+	// Match vertical rhythm to the gap below the bordered name field → checkbox:
+	// the input box adds visual weight, so we add explicit space before Create (and help).
+	formSectionGap := 1
+
+	createBtn := wizardFormButton("Create", m.nameFormFocus == focusWizardSubmit, true)
+	buttonRow := lipgloss.NewStyle().MarginTop(formSectionGap).Render(createBtn)
+
 	help := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#626262")).
-		Render("[Enter] Create • [Esc] Back")
+		Foreground(lipgloss.Color("#52525B")).
+		MarginTop(formSectionGap).
+		Render(helpTextNameStep(m.selectedLoader == "fabric"))
 
 	return lipgloss.JoinVertical(
 		lipgloss.Left,
 		title,
 		summary,
-		"",
-		inputStyle.Render(m.nameInput.View()),
-		errText,
-		"",
+		nameBlock,
+		starterBlock,
+		buttonRow,
 		help,
 	)
+}
+
+// wizardCheckboxGlyph uses □ / ■ — one monospace cell each, so the glyph is always square in the grid.
+// Lipgloss borders + Width/Height do not reliably map to equal row/column counts, which caused tall boxes.
+func wizardCheckboxGlyph(checked, focused bool) string {
+	if checked {
+		return lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#34D399")).
+			Render("■")
+	}
+	st := lipgloss.NewStyle().Foreground(lipgloss.Color("#52525B"))
+	if focused {
+		st = st.Foreground(lipgloss.Color("#10B981"))
+	}
+	return st.Render("□")
+}
+
+func wizardFormButton(label string, focused, primary bool) string {
+	st := lipgloss.NewStyle().
+		Padding(0, 2).
+		Border(lipgloss.RoundedBorder())
+	if primary {
+		if focused {
+			st = st.BorderForeground(lipgloss.Color("#10B981")).Foreground(lipgloss.Color("#FAFAFA")).Bold(true)
+		} else {
+			st = st.BorderForeground(lipgloss.Color("#3F3F46")).Foreground(lipgloss.Color("#A1A1AA"))
+		}
+	} else {
+		if focused {
+			st = st.BorderForeground(lipgloss.Color("#71717A")).Foreground(lipgloss.Color("#E4E4E7"))
+		} else {
+			st = st.BorderForeground(lipgloss.Color("#27272A")).Foreground(lipgloss.Color("#71717A"))
+		}
+	}
+	return st.Render(label)
+}
+
+func helpTextNameStep(fabric bool) string {
+	base := "[Tab] / [Shift+Tab] / [↑][↓] move · [Enter] create · [Esc] back to loader"
+	if fabric {
+		return base + " · [Space] toggle mods option"
+	}
+	return base
 }
 
 func validateInstanceName(name string, existingNames map[string]struct{}) error {

--- a/internal/ui/wizard.go
+++ b/internal/ui/wizard.go
@@ -22,6 +22,13 @@ const (
 	StepEnterName
 )
 
+// loaderChoice is one row in the mod loader step (extensible for future loaders).
+type loaderChoice struct {
+	Label      string
+	ID         string // persisted to Instance.Loader when not ComingSoon
+	ComingSoon bool
+}
+
 // WizardModel is the new instance wizard
 type WizardModel struct {
 	step   WizardStep
@@ -34,14 +41,16 @@ type WizardModel struct {
 	showSnaps   bool
 
 	// Loader selection
-	selectedVersion string
-	loaderIndex     int
-	loaders         []string
+	selectedVersion     string
+	loaderIndex         int
+	loaderChoices       []loaderChoice
+	selectedLoader      string // instance loader id: vanilla, fabric
+	selectedLoaderLabel string // display label for summary
+	loaderHint          string // e.g. coming-soon message
 
 	// Name input
-	nameInput      textinput.Model
-	selectedLoader string
-	nameErr        string
+	nameInput textinput.Model
+	nameErr   string
 
 	existingNames map[string]struct{}
 
@@ -101,9 +110,14 @@ func NewWizardModel(instances []*core.Instance) *WizardModel {
 	}
 
 	return &WizardModel{
-		step:          StepSelectVersion,
-		versionList:   vl,
-		loaders:       []string{"Vanilla", "Fabric", "Forge", "Quilt"},
+		step:        StepSelectVersion,
+		versionList: vl,
+		loaderChoices: []loaderChoice{
+			{Label: "Vanilla", ID: "vanilla"},
+			{Label: "Fabric", ID: "fabric"},
+			{Label: "Forge (coming soon)", ID: "", ComingSoon: true},
+			{Label: "Quilt (coming soon)", ID: "", ComingSoon: true},
+		},
 		nameInput:     ti,
 		loading:       true,
 		existingNames: existingNames,
@@ -175,10 +189,12 @@ func (m *WizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case "up", "k":
 			if m.step == StepSelectLoader && m.loaderIndex > 0 {
+				m.loaderHint = ""
 				m.loaderIndex--
 			}
 		case "down", "j":
-			if m.step == StepSelectLoader && m.loaderIndex < len(m.loaders)-1 {
+			if m.step == StepSelectLoader && m.loaderIndex < len(m.loaderChoices)-1 {
+				m.loaderHint = ""
 				m.loaderIndex++
 			}
 		}
@@ -208,9 +224,16 @@ func (m *WizardModel) handleEnter() (*WizardModel, tea.Cmd) {
 			m.step = StepSelectLoader
 		}
 	case StepSelectLoader:
-		m.selectedLoader = strings.ToLower(m.loaders[m.loaderIndex])
+		ch := m.loaderChoices[m.loaderIndex]
+		if ch.ComingSoon {
+			m.loaderHint = "That loader isn't available yet — choose Vanilla or Fabric."
+			return m, nil
+		}
+		m.selectedLoader = ch.ID
+		m.selectedLoaderLabel = ch.Label
+		m.loaderHint = ""
 		m.step = StepEnterName
-		m.nameInput.SetValue(fmt.Sprintf("%s %s", m.selectedVersion, m.loaders[m.loaderIndex]))
+		m.nameInput.SetValue(fmt.Sprintf("%s %s", m.selectedVersion, ch.Label))
 		m.nameInput.Focus()
 	case StepEnterName:
 		name := strings.TrimSpace(m.nameInput.Value())
@@ -315,18 +338,26 @@ func (m *WizardModel) viewLoaderStep() string {
 		Render(fmt.Sprintf("Select Mod Loader for %s", m.selectedVersion))
 
 	var loaderList strings.Builder
-	for i, loader := range m.loaders {
+	for i, ch := range m.loaderChoices {
 		style := lipgloss.NewStyle().Padding(0, 2)
+		label := ch.Label
+		prefix := "  "
 		if i == m.loaderIndex {
-			style = style.
-				Bold(true).
-				Foreground(lipgloss.Color("#10B981")).
-				SetString("▸ " + loader)
-		} else {
-			style = style.SetString("  " + loader)
+			prefix = "▸ "
+			style = style.Bold(true).Foreground(lipgloss.Color("#10B981"))
+		} else if ch.ComingSoon {
+			style = style.Foreground(lipgloss.Color("#626262"))
 		}
+		style = style.SetString(prefix + label)
 		loaderList.WriteString(style.Render())
 		loaderList.WriteString("\n")
+	}
+
+	hintBlock := ""
+	if m.loaderHint != "" {
+		hintBlock = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#FBBF24")).
+			Render(m.loaderHint) + "\n\n"
 	}
 
 	help := lipgloss.NewStyle().
@@ -339,7 +370,7 @@ func (m *WizardModel) viewLoaderStep() string {
 		"",
 		loaderList.String(),
 		"",
-		help,
+		hintBlock+help,
 	)
 }
 
@@ -351,7 +382,7 @@ func (m *WizardModel) viewNameStep() string {
 
 	summary := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#A1A1AA")).
-		Render(fmt.Sprintf("Minecraft %s • %s", m.selectedVersion, m.loaders[m.loaderIndex]))
+		Render(fmt.Sprintf("Minecraft %s • %s", m.selectedVersion, m.selectedLoaderLabel))
 
 	inputStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).

--- a/internal/ui/wizard_test.go
+++ b/internal/ui/wizard_test.go
@@ -1,6 +1,10 @@
 package ui
 
-import "testing"
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
 
 func TestValidateInstanceName(t *testing.T) {
 	existing := map[string]struct{}{
@@ -33,5 +37,59 @@ func TestValidateInstanceName(t *testing.T) {
 		if !tc.wantErr && err != nil {
 			t.Fatalf("unexpected error for %q: %v", tc.name, err)
 		}
+	}
+}
+
+func TestNameStep_spaceTogglesFabricStarterCheckbox(t *testing.T) {
+	m := NewWizardModel(nil)
+	m.step = StepEnterName
+	m.selectedLoader = "fabric"
+	m.nameStepSetFocus(focusWizardStarterCheckbox)
+	m.installStarterMods = false
+
+	keyTypes := []tea.Key{
+		{Type: tea.KeySpace},
+		{Type: tea.KeyRunes, Runes: []rune{' '}},
+	}
+	for _, k := range keyTypes {
+		m.installStarterMods = false
+		next, _ := m.Update(tea.KeyMsg(k))
+		w := next.(*WizardModel)
+		if !w.installStarterMods {
+			t.Fatalf("key %+v should toggle installStarterMods on", k)
+		}
+	}
+}
+
+func TestMoveLoaderSelection_skipsComingSoon(t *testing.T) {
+	m := &WizardModel{
+		loaderChoices: []loaderChoice{
+			{Label: "Fabric", ID: "fabric"},
+			{Label: "Vanilla", ID: "vanilla"},
+			{Label: "Forge (coming soon)", ID: "", ComingSoon: true},
+			{Label: "Quilt (coming soon)", ID: "", ComingSoon: true},
+		},
+		loaderIndex: 0,
+	}
+	m.moveLoaderSelection(1)
+	if m.loaderIndex != 1 {
+		t.Fatalf("down from Fabric: got index %d want 1 (Vanilla)", m.loaderIndex)
+	}
+	m.moveLoaderSelection(1)
+	if m.loaderIndex != 0 {
+		t.Fatalf("down from Vanilla should wrap to Fabric, got index %d", m.loaderIndex)
+	}
+	m.moveLoaderSelection(-1)
+	if m.loaderIndex != 1 {
+		t.Fatalf("up from Fabric should wrap to Vanilla, got index %d", m.loaderIndex)
+	}
+	m.loaderIndex = 3 // stale: on a coming-soon row
+	m.moveLoaderSelection(1)
+	if m.loaderIndex != 0 {
+		t.Fatalf("snap from coming-soon: got %d want Fabric (0)", m.loaderIndex)
+	}
+	m.moveLoaderSelection(1)
+	if m.loaderIndex != 1 {
+		t.Fatalf("after snap, down → Vanilla: got %d", m.loaderIndex)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/quasar/mctui/internal/app"
+	"github.com/mctui/mctui/internal/app"
 )
 
 var version = "dev"


### PR DESCRIPTION
## Summary

This PR bundles four related improvements to **authentication**, **launch UX**, **Fabric support**, and **mods workflow**. Together they make online launches safer when sessions are invalid, give control over how noisy the game log is during launch, add first-class **Fabric** instances with correct merged version metadata, and ship an in-app **Modrinth** browser plus optional **starter mods** for new Fabric instances.

## User-facing

### Microsoft session validation

Online launch is gated on a valid Minecraft Services session. The home screen reflects session state (checking / valid / needs sign-in / uncertain, e.g. network). Offline launch remains available where appropriate.

### Launch log verbosity

While the game is starting, log output can be tuned (e.g. errors-only by default). **`[v]`** cycles verbosity; the choice is **persisted** in config (`launchLogVerbosity`).

### Fabric loader

New instances can use **Fabric**. Version resolution **merges** Mojang’s version JSON with Fabric’s profile from `meta.fabricmc.net`, caches the merged result, and builds a sensible classpath. Switching **game version / loader / loader version** invalidates the **skip-download** cache via a **fingerprint** so assets aren’t wrongly reused.

### Mods (Fabric only)

From home, **`[m]`** opens a **Modrinth** browser (search, install into the instance `mods` folder, remove jars, catalog file for “installed via mctui” badges). Optional **starter bundle** (Fabric API, Mod Menu, Sodium, Lithium) at instance creation; installs can be **canceled** when leaving the screen. **Settings** (`**[s]**`) opens a placeholder screen with **Esc** back to home.

## Technical

- **Auth / API**: Validates tokens via the Minecraft profile path; tests and Makefile helpers (e.g. `make damage-auth`) support manual testing of invalid-session behavior.
- **Loader**: `internal/loader/fabric` — resolve, merge, Maven paths; merge tests cover library merging, dedupe, and ASM edge cases.
- **Mods**: `internal/mods` — Modrinth service layer, catalog (`.mctui-modrinth.json`), installed jar listing, starter install at launch with progress; **`ModInstallDoneMsg`** routed through the app so installs don’t leak state after navigation.
- **Catalog safety**: New installs **fail** if the existing catalog file is unreadable (avoids wiping entries on corrupt JSON).

## Files / scope

Roughly: `internal/api` (auth), `internal/config`, `internal/launch` (verbosity + pipeline), `internal/loader` + `internal/loader/fabric`, `internal/mods`, `internal/ui` (home, launch, wizard, mods stack, messages), `internal/app`, `Makefile`, `go.mod` / `go.sum`.

## How to test

- Sign in with MSA; confirm home session line and that online launch is blocked or redirected when the session is invalid (use `make damage-auth` if available to simulate).
- Launch once; use **`[v]`** on the launch screen and confirm persistence across runs.
- Create a **Fabric** instance, launch online/offline; change MC version or loader and confirm downloads refresh when expected.
- Open **Mods** on a Fabric instance: search, install, remove; optional **starter mods** from the wizard; **Esc** during download cancels; corrupt `.mctui-modrinth.json` should block catalog updates with an error, not wipe data.